### PR TITLE
WIP: making devtools work with apps in iframes

### DIFF
--- a/background.js
+++ b/background.js
@@ -1,9 +1,21 @@
+var frameURLs = new Set([]);
+
+function sendFrameURLs() {
+    chrome.runtime.sendMessage({
+        type: "update-frames",
+        frameURLs: Array.from(frameURLs)
+    });
+
+    setTimeout(sendFrameURLs, 2000);
+}
+
 chrome.runtime.onConnect.addListener(function(port) {	
     if (port.name === "canjs-devtools") {
         // listen to messages from the canjs-devtools.js	
         port.onMessage.addListener(function(msg, port) {	
-            // pass messages through to extension panels
-            chrome.runtime.sendMessage(msg);	
+            frameURLs.add( port.sender.url );
         });	
     }
+
+    sendFrameURLs();
 });

--- a/background.js
+++ b/background.js
@@ -1,0 +1,9 @@
+chrome.runtime.onConnect.addListener(function(port) {	
+    if (port.name === "canjs-devtools") {
+        // listen to messages from the canjs-devtools.js	
+        port.onMessage.addListener(function(msg, port) {	
+            // pass messages through to extension panels
+            chrome.runtime.sendMessage(msg);	
+        });	
+    }
+});

--- a/background.js
+++ b/background.js
@@ -9,12 +9,12 @@ function sendFrameURLs() {
     setTimeout(sendFrameURLs, 2000);
 }
 
-chrome.runtime.onConnect.addListener(function(port) {	
+chrome.runtime.onConnect.addListener(function(port) {
     if (port.name === "canjs-devtools") {
-        // listen to messages from the canjs-devtools.js	
-        port.onMessage.addListener(function(msg, port) {	
+        // listen to messages from the canjs-devtools.js
+        port.onMessage.addListener(function(msg, port) {
             frameURLs.add( port.sender.url );
-        });	
+        });
     }
 
     sendFrameURLs();

--- a/bindings-graph/bindings-graph.js
+++ b/bindings-graph/bindings-graph.js
@@ -9,15 +9,32 @@ chrome.runtime.onMessage.addListener(function(msg, sender) {
     }
 });
 
-
 can.Component.extend({
     tag: "canjs-devtools-bindings-graph",
+
+    view: `
+        {{#if error}}
+            <h2>{{error}}</h2>
+        {{else}}
+            {{#unless selectedObj}}
+                <h2>Select an element to see its bindings graph</h2>
+            {{else}}
+                <bindings-graph
+                    graphData:from="graphData"
+                    availableKeys:from="availableKeys"
+                    selectedObj:from="selectedObj"
+                    selectedKey:bind="selectedKey"
+                ></bindings-graph>
+            {{/unless}}
+        {{/if}}
+    `,
 
     ViewModel: {
         graphData: { Type: can.DefineMap, Default: can.DefineMap },
         availableKeys: { Type: can.DefineList, Default: can.DefineList },
         selectedObj: "string",
         selectedKey: "string",
+        error: "string",
 
         connectedCallback() {
             var vm = this;
@@ -28,22 +45,48 @@ can.Component.extend({
                         "__CANJS_DEVTOOLS__.getBindingsGraphData($0, '" + vm.selectedKey + "')",
                         { frameURL: registeredFrameURLs[i] },
                         function(result, isException) {
-                            if (result) {
-                                vm.selectedObj = result.selectedObj;
-                                vm.availableKeys.replace(result.availableKeys);
-                                if (result.graphData) {
-                                    vm.graphData = result.graphData;
-                                } else {
-                                    can.Reflect.deleteKeyValue(vm, "graphData");
-                                }
+                            if (isException) {
+                                return;
+                            }
+
+                            var status = result.status;
+                            var detail = result.detail;
+
+                            switch(status) {
+                                case "ignore":
+                                    break;
+                                case "error":
+                                    vm.error = detail;
+                                    break;
+                                case "success":
+                                    vm.error = null;
+                                    vm.selectedObj = detail.selectedObj;
+                                    vm.availableKeys.replace(detail.availableKeys);
+                                    if (detail.graphData) {
+                                        vm.graphData = detail.graphData;
+                                    } else {
+                                        can.Reflect.deleteKeyValue(vm, "graphData");
+                                    }
+                                    break;
                             }
                         }
                     )
                 }
             };
 
-            // load initial data
-            loadGraphData();
+            // there is a slight delay between when the devtools panel is opened
+            // and when $0 will be set correctly so that the graph data can be returned
+            // so this sets up polling to load the initial data.
+            // once the data is inititally loaded, polling is not necessary because it
+            // will be updated by the `onSelectionChanged` handler below.
+            (function loadInitialGraphData() {
+                // load initial data
+                loadGraphData();
+
+                if (!vm.selectedObj) {
+                    setTimeout(loadInitialGraphData, 100);
+                }
+            }());
 
             // update graph data when user selects a new element
             chrome.devtools.panels.elements.onSelectionChanged.addListener(loadGraphData);
@@ -56,14 +99,5 @@ can.Component.extend({
                 chrome.devtools.panels.elements.onSelectionChanged.removeListener(loadGraphData);
             };
         }
-    },
-
-    view: `
-        <bindings-graph
-			graphData:from="graphData"
-            availableKeys:from="availableKeys"
-            selectedObj:from="selectedObj"
-            selectedKey:bind="selectedKey"
-        ></bindings-graph>
-    `
+    }
 });

--- a/canjs-devtools-content-script.js
+++ b/canjs-devtools-content-script.js
@@ -1,0 +1,14 @@
+var port = chrome.runtime.connect({ name: "canjs-devtools" });
+
+// listen for messages passed from injected-script
+// and pass them back to extension panels
+document.addEventListener("__CANJS_DEVTOOLS_MSG__", function(response) {	
+    var msg = response.detail;
+	port.postMessage(msg);
+});
+
+// inject script into page to add __CANJS_DEVTOOLS__ namespace to window
+// and register page with devtools extension
+var s = document.createElement("script");  
+s.src = chrome.extension.getURL("canjs-devtools-injected-script.js");  
+document.body.appendChild(s);

--- a/canjs-devtools-content-script.js
+++ b/canjs-devtools-content-script.js
@@ -2,13 +2,16 @@ var port = chrome.runtime.connect({ name: "canjs-devtools" });
 
 // listen for messages passed from injected-script
 // and pass them back to extension panels
-document.addEventListener("__CANJS_DEVTOOLS_MSG__", function(response) {	
-    var msg = response.detail;
-	port.postMessage(msg);
+document.addEventListener("__CANJS_DEVTOOLS_REGISTER__", function(response) {
+	port.postMessage("register");
 });
 
 // inject script into page to add __CANJS_DEVTOOLS__ namespace to window
 // and register page with devtools extension
-var s = document.createElement("script");  
-s.src = chrome.extension.getURL("canjs-devtools-injected-script.js");  
-document.body.appendChild(s);
+function injectScript(el) {
+    var s = document.createElement("script");
+    s.src = chrome.extension.getURL("canjs-devtools-injected-script.js");
+    el.appendChild(s);
+}
+
+injectScript( document.body );

--- a/canjs-devtools-injected-script.js
+++ b/canjs-devtools-injected-script.js
@@ -1,5 +1,142 @@
 // expose devtools namespace on the window
 var __CANJS_DEVTOOLS__ = {
+    /*
+     * methods called by devtools panels
+     */
+	getViewModelData: function(el) {
+        // if $0 is not in this frame, el will be null
+        if (!el) {
+            return this.makeIgnoreResponse("$0 is not in this frame");
+        }
+
+        var can = el.ownerDocument.defaultView.can;
+
+        // the page that $0 is in may not have can
+        if (!can) {
+            return this.makeErrorResponse("`window.can` is not defined");
+        }
+
+        var elementWithViewModel = this.getNearestElementWithViewModel(el, can);
+
+		if (elementWithViewModel) {
+			return this.makeSuccessResponse({
+                type: "viewModel",
+				tagName: elementWithViewModel.tagName,
+				viewModel: this.getSerializedViewModel( elementWithViewModel, can )
+			});
+		} else {
+            return this.makeErrorResponse("<" + el.tagName.toLowerCase() + "> does not have a viewModel");
+		}
+    },
+
+    setViewModelKeyValue: function(el, key, value) {
+        // if $0 is not in this frame, el will be null
+        if (!el) {
+            return this.makeIgnoreResponse("$0 is not in this frame");
+        }
+
+        var can = el.ownerDocument.defaultView.can;
+
+        // the page that $0 is in may not have can
+        if (!can) {
+            return this.makeErrorResponse("`window.can` is not defined");
+        }
+
+        var elementWithViewModel = this.getNearestElementWithViewModel(el, can);
+
+        if (elementWithViewModel) {
+            can.Reflect.setKeyValue( can.viewModel( elementWithViewModel ), key, value);
+        }
+    },
+
+    getBindingsGraphData: function(el, key) {
+        // if $0 is not in this frame, el will be null
+        if (!el) {
+            return;
+        }
+
+        var can = el.ownerDocument.defaultView.can;
+
+        // the page that $0 is in may not have can
+        if (!can) {
+            return;
+        }
+
+        var hasViewModel = el[can.Symbol.for("can.viewModel")];
+        var obj = hasViewModel ? can.viewModel(el) : el;
+
+        var graphData;
+
+        if (can.debug && can.debug.getGraph && can.debug.formatGraph) {
+            graphData = can.debug.formatGraph( can.debug.getGraph( obj, key ) );
+        }
+
+        return {
+            availableKeys: hasViewModel ? this.getViewModelKeys(el, can) : this.getElementKeys(el),
+            selectedObj: "<" + el.tagName.toLowerCase() + ">" + (hasViewModel ? ".viewModel" : ""),
+            graphData: graphData
+        };
+    },
+
+    queuesStack: function() {
+        var can = window.can;
+
+        if (!can) {
+            // don't show an error for this
+            return;
+        }
+
+        var stack = can.queues.stack();
+
+        return stack.map(function(task) {
+            return {
+                queue: task.meta.stack.name,
+                context: can.Reflect.getName(task.context),
+                fn: can.Reflect.getName(task.fn),
+                reason: task.meta && task.meta.reasonLog && task.meta.reasonLog.join(" ")
+            };
+        });
+    },
+
+    inspectTask(index) {
+        var can = window.can;
+
+        if (!can) {
+            return this.makeErrorResponse("`window.can` is not defined");
+        }
+
+        var stack = can.queues.stack();
+
+        if (stack && stack[index] && stack[index].fn) {
+            inspect( stack[index].fn );
+        }
+    },
+
+    /*
+     * methods used to build responses
+     */
+    makeResponse(status, detail) {
+        return {
+            status: status,
+            detail: detail
+        };
+    },
+
+    makeIgnoreResponse(detail) {
+        return this.makeResponse("ignore", detail);
+    },
+
+    makeErrorResponse: function(detail) {
+        return this.makeResponse("error", detail);
+    },
+
+    makeSuccessResponse: function(detail) {
+        return this.makeResponse("success", detail);
+    },
+
+    /*
+     * helper methods
+     */
     getNearestElementWithViewModel: function(el, can) {
         var vm = el[can.Symbol.for("can.viewModel")];
         return vm ?
@@ -35,87 +172,6 @@ var __CANJS_DEVTOOLS__ = {
         return sortedViewModel;
     },
 
-	getViewModelData: function(el) {
-        // if $0 is not in this frame, el will be null
-        if (!el) {
-            return;
-        }
-
-        var can = el.ownerDocument.defaultView.can;
-
-        // the page that $0 is in may not have can
-        if (!can) {
-            return;
-        }
-
-        var elementWithViewModel = this.getNearestElementWithViewModel(el, can);
-
-		if (elementWithViewModel) {
-			return {
-                type: "viewModel",
-				tagName: elementWithViewModel.tagName,
-				viewModel: this.getSerializedViewModel( elementWithViewModel, can )
-			};
-		} else {
-			return {
-                type: "viewModel",
-				tagName: el.tagName
-			};
-		}
-    },
-
-    setViewModelKeyValue: function(el, key, value) {
-        // if $0 is not in this frame, el will be null
-        if (!el) {
-            return;
-        }
-
-        var can = el.ownerDocument.defaultView.can;
-
-        // the page that $0 is in may not have can
-        if (!can) {
-            return;
-        }
-
-        var elementWithViewModel = this.getNearestElementWithViewModel(el, can);
-
-        if (elementWithViewModel) {
-            can.Reflect.setKeyValue( can.viewModel( elementWithViewModel ), key, value);
-        }
-    },
-
-    inspectTask(index) {
-        var can = window.can;
-
-        if (!can) {
-            return;
-        }
-
-        var stack = can.queues.stack();
-
-        if (stack && stack[index] && stack[index].fn) {
-            inspect( stack[index].fn );
-        }
-    },
-
-    queuesStack: function() {
-        var can = window.can;
-
-        if (!can) {
-            return;
-        }
-
-        var stack = can.queues.stack();
-
-        return stack.map(function(task) {
-            return {
-                queue: task.meta.stack.name,
-                context: can.Reflect.getName(task.context),
-                fn: can.Reflect.getName(task.fn),
-                reason: task.meta && task.meta.reasonLog && task.meta.reasonLog.join(" ")
-            };
-        });
-    },
 
     getViewModelKeys: function(el, can) {
         return Object.keys( this.getSerializedViewModel(el, can) );
@@ -131,37 +187,7 @@ var __CANJS_DEVTOOLS__ = {
             keysSet.add( key );
         }
 
-
         return Array.from(keysSet);
-    },
-
-    getBindingsGraphData: function(el, key) {
-        // if $0 is not in this frame, el will be null
-        if (!el) {
-            return;
-        }
-
-        var can = el.ownerDocument.defaultView.can;
-
-        // the page that $0 is in may not have can
-        if (!can) {
-            return;
-        }
-
-        var hasViewModel = el[can.Symbol.for("can.viewModel")];
-        var obj = hasViewModel ? can.viewModel(el) : el;
-
-        var graphData;
-
-        if (can.debug && can.debug.getGraph && can.debug.formatGraph) {
-            graphData = can.debug.formatGraph( can.debug.getGraph( obj, key ) );
-        }
-
-        return {
-            availableKeys: hasViewModel ? this.getViewModelKeys(el, can) : this.getElementKeys(el),
-            selectedObj: "<" + el.tagName.toLowerCase() + ">" + (hasViewModel ? ".viewModel" : ""),
-            graphData: graphData
-        };
     }
 };
 

--- a/canjs-devtools-injected-script.js
+++ b/canjs-devtools-injected-script.js
@@ -115,6 +115,53 @@ var __CANJS_DEVTOOLS__ = {
                 reason: task.meta && task.meta.reasonLog && task.meta.reasonLog.join(" ")
             };
         });
+    },
+
+    getViewModelKeys: function(el, can) {
+        return Object.keys( this.getSerializedViewModel(el, can) );
+    },
+
+    getElementKeys: function(el) {
+        var keysSet = new Set([]);
+        var keysMap = el.attributes;
+
+        for (var i=0; i<keysMap.length; i++) {
+            var key = keysMap[i].name.split(/:to|:from|:bind/)[0];
+            key = key.split(":")[key.split(":").length - 1]
+            keysSet.add( key );
+        }
+
+
+        return Array.from(keysSet);
+    },
+
+    getBindingsGraphData: function(el, key) {
+        // if $0 is not in this frame, el will be null
+        if (!el) {
+            return;
+        }
+
+        var can = el.ownerDocument.defaultView.can;
+
+        // the page that $0 is in may not have can
+        if (!can) {
+            return;
+        }
+
+        var hasViewModel = el[can.Symbol.for("can.viewModel")];
+        var obj = hasViewModel ? can.viewModel(el) : el;
+
+        var graphData;
+
+        if (can.debug && can.debug.getGraph && can.debug.formatGraph) {
+            graphData = can.debug.formatGraph( can.debug.getGraph( obj, key ) );
+        }
+
+        return {
+            availableKeys: hasViewModel ? this.getViewModelKeys(el, can) : this.getElementKeys(el),
+            selectedObj: "<" + el.tagName.toLowerCase() + ">" + (hasViewModel ? ".viewModel" : ""),
+            graphData: graphData
+        };
     }
 };
 

--- a/canjs-devtools-injected-script.js
+++ b/canjs-devtools-injected-script.js
@@ -83,14 +83,18 @@ var __CANJS_DEVTOOLS__ = {
         var can = window.can;
 
         if (!can) {
-            // don't show an error for this
+            // don't show an error for this because unlike ViewModel and Graph functions,
+            // this can't check if it is the correct frame by using $0.
+            // So just assume it's not the correct frame if `window.can` is undefined.
             return this.makeIgnoreResponse(this.NO_CAN_MSG);
         }
 
         var stack = can.queues.stack();
 
-        return this.makeSuccessResponse(
-            stack.map(function(task) {
+        return this.makeSuccessResponse({
+            frameURL: window.location.href,
+
+            stack: stack.map(function(task) {
                 return {
                     queue: task.meta.stack.name,
                     context: can.Reflect.getName(task.context),
@@ -98,7 +102,7 @@ var __CANJS_DEVTOOLS__ = {
                     reason: task.meta && task.meta.reasonLog && task.meta.reasonLog.join(" ")
                 };
             })
-        );
+        });
     },
 
     inspectTask(index) {

--- a/canjs-devtools-injected-script.js
+++ b/canjs-devtools-injected-script.js
@@ -1,5 +1,40 @@
 // expose devtools namespace on the window
 var __CANJS_DEVTOOLS__ = {
+    getNearestElementWithViewModel: function(el, can) {
+        var vm = el[can.Symbol.for("can.viewModel")];
+        return vm ?
+            el :
+            el.parentNode ?
+            this.getNearestElementWithViewModel(el.parentNode, can) :
+            undefined;
+    },
+
+    getSerializedViewModel: function(el, can) {
+        var viewModel = can.viewModel(el);
+        var viewModelData = viewModel.serialize();
+
+        // if viewModel Type supports getOwnKeys, add any non-enumerable properties
+        if (viewModel[ can.Symbol.for( "can.getOwnKeys" ) ]) {
+            var viewModelKeys = can.Reflect.getOwnKeys( viewModel );
+
+            for (var i=0; i<viewModelKeys.length; i++) {
+                var key = viewModelKeys[i];
+                if (!viewModelData[ key ]) {
+                    viewModelData[key] = can.Reflect.getKeyValue( viewModel, key );
+                }
+            }
+        }
+
+        // sort viewModel data in alphabetical order
+        var sortedViewModel = {};
+
+        Object.keys(viewModelData).sort().forEach(function(key) {
+            sortedViewModel[key] = viewModelData[key];
+        });
+
+        return sortedViewModel;
+    },
+
 	getViewModelData: function(el) {
         // if $0 is not in this frame, el will be null
         if (!el) {
@@ -13,41 +48,13 @@ var __CANJS_DEVTOOLS__ = {
             return;
         }
 
-		var elementWithViewModel = (function getElementWithViewModel(el) {
-			var vm = el[can.Symbol.for("can.viewModel")];
-			return vm ?
-				el :
-				el.parentNode ?
-				getElementWithViewModel(el.parentNode) :
-				undefined;
-		}(el));
-
-		var getViewModelData = function(el) {
-			var viewModel = can.viewModel(el);
-			var viewModelData = viewModel.serialize();
-			var viewModelKeys = can.Reflect.getOwnKeys( viewModel );
-
-			for (var i=0; i<viewModelKeys.length; i++) {
-				var key = viewModelKeys[i];
-				if (!viewModelData[ key ]) {
-					viewModelData[key] = can.Reflect.getKeyValue( viewModel, key );
-				}
-			}
-
-			var sortedViewModel = {};
-
-			Object.keys(viewModelData).sort().forEach(function(key) {
-				sortedViewModel[key] = viewModelData[key];
-			});
-
-			return sortedViewModel;
-		};
+        var elementWithViewModel = this.getNearestElementWithViewModel(el, can);
 
 		if (elementWithViewModel) {
 			return {
                 type: "viewModel",
 				tagName: elementWithViewModel.tagName,
-				viewModel: getViewModelData( elementWithViewModel )
+				viewModel: this.getSerializedViewModel( elementWithViewModel, can )
 			};
 		} else {
 			return {
@@ -55,19 +62,28 @@ var __CANJS_DEVTOOLS__ = {
 				tagName: el.tagName
 			};
 		}
-	},
+    },
 
-    register: function(detail) {
-        var msg = new CustomEvent("__CANJS_DEVTOOLS_MSG__", {	
-            detail: {
-                type: "register",
-                frameURL: window.location.href
-            }
-        });	
+    setViewModelKeyValue: function(el, key, value) {
+        // if $0 is not in this frame, el will be null
+        if (!el) {
+            return;
+        }
 
-        document.dispatchEvent(msg);
+        var can = el.ownerDocument.defaultView.can;
+
+        // the page that $0 is in may not have can
+        if (!can) {
+            return;
+        }
+
+        var elementWithViewModel = this.getNearestElementWithViewModel(el, can);
+
+        if (elementWithViewModel) {
+            can.Reflect.setKeyValue( can.viewModel( elementWithViewModel ), key, value);
+        }
     }
 };
 
-// register page's URL so that inspectedWindow.eval can call devtools functions in this frame
-__CANJS_DEVTOOLS__.register();
+// register page so inspectedWindow.eval can call devtools functions in this frame
+document.dispatchEvent( new CustomEvent("__CANJS_DEVTOOLS_REGISTER__") );

--- a/canjs-devtools-injected-script.js
+++ b/canjs-devtools-injected-script.js
@@ -1,0 +1,56 @@
+// expose devtools namespace on the window
+var __CANJS_DEVTOOLS__ = {
+    selectedElement: null,
+    can: null,
+
+    patchMethod: function(can, package, method, sendData) {
+        var devtools = this;
+
+        var orig = can[package][method];
+        can[package][method] = function() {
+            var ret = orig.apply(this, arguments);
+
+            // if an element is selected in devtools, send new ViewModel / Binding data
+            if (devtools.selectedElement) {
+                sendData();
+            }
+
+            return ret;
+        };
+    },
+
+    setSelectedElement: function(el) {
+        this.selectedElement = el;
+
+        if (el) {
+            var can = this.can = el.ownerDocument.defaultView.can;
+
+            if (can && !can.__CANJS_DEVTOOLS_PATCHED__) {
+                // patch CanJS methods to send data back to devtools
+                this.patchMethod(can, "Reflect", "setKeyValue", this.sendViewModelData.bind(this));
+                this.patchMethod(can, "Reflect", "getKeyValue", this.sendViewModelData.bind(this));
+                this.patchMethod(can, "Reflect", "setValue", this.sendViewModelData.bind(this));
+                this.patchMethod(can, "Reflect", "getValue", this.sendViewModelData.bind(this));
+                // mark as patched so it is not patched more than once
+                can.__CANJS_DEVTOOLS_PATCHED__ = true;
+            }
+        }
+    },
+
+    sendViewModelData: function() {
+    },
+
+    sendMessage: function(detail) {
+        var msg = new CustomEvent("__CANJS_DEVTOOLS_MSG__", {	
+            detail: detail
+        });	
+
+        document.dispatchEvent(msg);
+    }
+};
+
+__CANJS_DEVTOOLS__.sendMessage({
+    type: "register",
+    frameURL: window.location.href
+});
+

--- a/canjs-devtools-injected-script.js
+++ b/canjs-devtools-injected-script.js
@@ -82,6 +82,39 @@ var __CANJS_DEVTOOLS__ = {
         if (elementWithViewModel) {
             can.Reflect.setKeyValue( can.viewModel( elementWithViewModel ), key, value);
         }
+    },
+
+    inspectTask(index) {
+        var can = window.can;
+
+        if (!can) {
+            return;
+        }
+
+        var stack = can.queues.stack();
+
+        if (stack && stack[index] && stack[index].fn) {
+            inspect( stack[index].fn );
+        }
+    },
+
+    queuesStack: function() {
+        var can = window.can;
+
+        if (!can) {
+            return;
+        }
+
+        var stack = can.queues.stack();
+
+        return stack.map(function(task) {
+            return {
+                queue: task.meta.stack.name,
+                context: can.Reflect.getName(task.context),
+                fn: can.Reflect.getName(task.fn),
+                reason: task.meta && task.meta.reasonLog && task.meta.reasonLog.join(" ")
+            };
+        });
     }
 };
 

--- a/index.js
+++ b/index.js
@@ -1,55 +1,3 @@
-// URLs of all frames that have registered that they
-// have a global `can` present
-var registeredFrameURLs = [];
-
-// when user selects a new element in the Elements panel, pass it to the 
-// "injected-script" so that viewModel and other data and bindings
-// can be read from the correct element
-chrome.devtools.panels.elements.onSelectionChanged.addListener(function() {
-    // call `setSelectedElement` in each registered frame
-    // this will set the selected element in the correct frame
-    // and remove the selected element in other frames since $0 will be null
-    for (var i=0; i<registeredFrameURLs.length; i++) {
-        chrome.devtools.inspectedWindow.eval(
-            "typeof __CANJS_DEVTOOLS__ !== 'undefined' && __CANJS_DEVTOOLS__.setSelectedElement($0)",
-            { frameURL: registeredFrameURLs[i] },
-            function(result, isException) {
-                if (isException) {
-                    console.error(isException);
-                }
-            }
-        );
-    }
-});
-
-// listen to messages from the injected-script
-chrome.runtime.onMessage.addListener(function(msg, sender) {
-    switch(msg.type) {
-        case "register":
-            if (registeredFrameURLs.length === 0) {
-                initializeSidebars();
-            }
-
-            registeredFrameURLs.push(msg.frameURL);
-            break;
-        default:
-            console.log("message received", msg);
-    }
-});
-
-var ifGlobals = function(globals, cb) {
-    var command = globals.map(function(global) {
-        return "typeof " + global + " !== 'undefined'";
-    }).join(" && ");
-
-    chrome.devtools.inspectedWindow.eval(
-        command,
-        function(result, isException) {
-            cb(!isException && result);
-        }
-    )
-};
-
 function initializeSidebars() {
     initializeSidebar(
         "CanJS ViewModel",
@@ -76,3 +24,6 @@ function initializeSidebar(name, location, page) {
         sidebar.setPage(page);
     });
 }
+
+// initialize all the sidebars when devtools loads
+initializeSidebars();

--- a/index.js
+++ b/index.js
@@ -1,24 +1,3 @@
-function initializeSidebars() {
-    initializeSidebar(
-        "CanJS ViewModel",
-        "elements",
-        "viewmodel-editor/index.html"
-    );
-//
-//    initializeSidebar(
-//        "CanJS Bindings Graph",
-//        "elements",
-//        "bindings-graph/index.html"
-//    );
-//
-//    initializeSidebar(
-//        "CanJS Queues Stack",
-//        "sources",
-//        // needs to have min-height of 50vh
-//        "queues-stack/index.html"
-//    );
-}
-
 function initializeSidebar(name, location, page) {
     chrome.devtools.panels[location].createSidebarPane(name, function(sidebar) {
         sidebar.setPage(page);
@@ -26,4 +5,21 @@ function initializeSidebar(name, location, page) {
 }
 
 // initialize all the sidebars when devtools loads
-initializeSidebars();
+initializeSidebar(
+    "CanJS ViewModel",
+    "elements",
+    "viewmodel-editor/index.html"
+);
+
+//initializeSidebar(
+//    "CanJS Bindings Graph",
+//    "elements",
+//    "bindings-graph/index.html"
+//);
+
+//initializeSidebar(
+//    "CanJS Queues Stack",
+//    "sources",
+//    // needs to have min-height of 50vh
+//    "queues-stack/index.html"
+//);

--- a/index.js
+++ b/index.js
@@ -11,11 +11,11 @@ initializeSidebar(
     "viewmodel-editor/index.html"
 );
 
-//initializeSidebar(
-//    "CanJS Bindings Graph",
-//    "elements",
-//    "bindings-graph/index.html"
-//);
+initializeSidebar(
+    "CanJS Bindings Graph",
+    "elements",
+    "bindings-graph/index.html"
+);
 
 initializeSidebar(
     "CanJS Queues Stack",

--- a/index.js
+++ b/index.js
@@ -17,9 +17,8 @@ initializeSidebar(
 //    "bindings-graph/index.html"
 //);
 
-//initializeSidebar(
-//    "CanJS Queues Stack",
-//    "sources",
-//    // needs to have min-height of 50vh
-//    "queues-stack/index.html"
-//);
+initializeSidebar(
+    "CanJS Queues Stack",
+    "sources",
+    "queues-stack/index.html"
+);

--- a/manifest.json
+++ b/manifest.json
@@ -9,6 +9,17 @@
     },
     "manifest_version": 2,
     "devtools_page": "index.html",
+    "background": {
+        "scripts": [ "background.js" ]
+    },
+    "content_scripts": [ {
+        "all_frames": true,
+        "js": [ "canjs-devtools-content-script.js" ],
+        "matches": [ "*://*/*" ]
+    } ],    
+    "web_accessible_resources": [   
+        "canjs-devtools-injected-script.js"    
+    ],
     "permissions": [],
     "content_security_policy": "script-src 'self' 'unsafe-eval'; object-src 'self'"
 }

--- a/manifest.json
+++ b/manifest.json
@@ -16,9 +16,9 @@
         "all_frames": true,
         "js": [ "canjs-devtools-content-script.js" ],
         "matches": [ "*://*/*" ]
-    } ],    
-    "web_accessible_resources": [   
-        "canjs-devtools-injected-script.js"    
+    } ],
+    "web_accessible_resources": [
+        "canjs-devtools-injected-script.js"
     ],
     "permissions": [],
     "content_security_policy": "script-src 'self' 'unsafe-eval'; object-src 'self'"

--- a/queues-stack/queues-stack.js
+++ b/queues-stack/queues-stack.js
@@ -13,14 +13,20 @@ can.Component.extend({
     tag: "canjs-devtools-queues-stack",
 
     view: `
-        <queues-logstack
-            stack:from="stack"
-			inspectTask:from="inspectTask"
-        ></queues-logstack>
+        {{#if error}}
+            <h2>{{error}}</h2>
+        {{else}}
+            <queues-logstack
+                stack:from="stack"
+                inspectTask:from="inspectTask"
+            ></queues-logstack>
+        {{/if}}
     `,
 
     ViewModel: {
-	    stack: can.DefineList,
+        stack: { Type: can.DefineList, Default: can.DefineList },
+        error: "string",
+        activeFrame: "string",
 
         inspectTask(taskIndex) {
             for (var i=0; i<registeredFrameURLs.length; i++) {
@@ -29,7 +35,7 @@ can.Component.extend({
                     { frameURL: registeredFrameURLs[i] },
                     function(stack, isException) {
                         if (isException) {
-                            console.error(isException);
+                            return;
                         }
                     }
                 );
@@ -45,11 +51,41 @@ can.Component.extend({
                     chrome.devtools.inspectedWindow.eval(
                         "__CANJS_DEVTOOLS__.queuesStack()",
                         { frameURL: registeredFrameURLs[i] },
-                        function(stack, isException) {
-                            if (stack) {
-                                if (!vm.stack || vm.stack.length !== stack.length) {
-                                    vm.stack = stack;
-                                }
+                        function(result, isException) {
+                            if (isException) {
+                                return;
+                            }
+
+                            var status = result.status;
+                            var stack = result.detail.stack;
+                            var frameURL = result.detail.frameURL;
+
+                            switch(status) {
+                                case "ignore":
+                                    break;
+                                case "error":
+                                    vm.error = detail;
+                                    break;
+                                case "success":
+                                    // if response is received from a frame other than the
+                                    // last `activeFrame`, only overwrite data if there is
+                                    // data on the stack
+                                    var shouldUpdate =
+                                        (
+                                            frameURL === vm.activeFrame && // apply updates from the `activeFrame`
+                                            stack.length !== vm.stack.length // if the length is the same, we assume the list is the same so that sidebar doesn't flash
+                                        ) ||
+                                        (
+                                            frameURL !== vm.activeFrame && // apply updates from another frame only
+                                            stack.length !== 0 // if there are items on the stack
+                                        );
+
+                                    if (shouldUpdate) {
+                                        vm.activeFrame = frameURL;
+                                        vm.stack = stack;
+                                    }
+
+                                    break;
                             }
                         }
                     );

--- a/queues-stack/queues-stack.js
+++ b/queues-stack/queues-stack.js
@@ -1,46 +1,13 @@
-// run an expression in the page
-var pageEval = chrome.devtools.inspectedWindow.eval;
+// URLs of all frames that have registered that they
+// have a global `can` present
+var registeredFrameURLs = [];
 
-// tostring a function and wrap in an IIFE so it can be evaled
-var iifeify = function(fn) {
-    return "(" + fn.toString() + "())";
-};
-
-var POLLING_INTERVAL = 100;
-
-// helpers for accessing main page's `can`
-var canHelpers = {
-    queuesFilterStack: function() {
-        return can.queues.stack().map(function(task) {
-            return {
-                queue: task.meta.stack.name,
-                context: can.Reflect.getName(task.context),
-                fn: can.Reflect.getName(task.fn),
-                reason: task.meta && task.meta.reasonLog && task.meta.reasonLog.join(" ")
-            };
-        });
-    },
-
-    queuesStack() {
-        return new Promise(function(resolve, reject) {
-            pageEval(iifeify( canHelpers.queuesFilterStack ), function(result, isException) {
-                if (isException) {
-                    reject(isException);
-                }
-
-                resolve(result);
-            });
-        });
-    },
-
-    inspectTask(index) {
-        pageEval("inspect( can.queues.stack()[" + index + "].fn )", function(result, isException) {
-            if (isException) {
-                console.error(isException);
-            }
-        });
+// listen to messages from the injected-script
+chrome.runtime.onMessage.addListener(function(msg, sender) {
+    if (msg.type === "update-frames") {
+        registeredFrameURLs = msg.frameURLs;
     }
-};
+});
 
 can.Component.extend({
     tag: "canjs-devtools-queues-stack",
@@ -56,7 +23,17 @@ can.Component.extend({
 	    stack: can.DefineList,
 
         inspectTask(taskIndex) {
-            canHelpers.inspectTask(taskIndex);
+            for (var i=0; i<registeredFrameURLs.length; i++) {
+                chrome.devtools.inspectedWindow.eval(
+                    "__CANJS_DEVTOOLS__.inspectTask(" + taskIndex + ")",
+                    { frameURL: registeredFrameURLs[i] },
+                    function(stack, isException) {
+                        if (isException) {
+                            console.error(isException);
+                        }
+                    }
+                );
+            }
         },
 
         connectedCallback() {
@@ -64,14 +41,21 @@ can.Component.extend({
             var vm = this;
 
             var updateStack = function() {
-                canHelpers.queuesStack()
-                    .then(function(stack) {
-                        if (!vm.stack || vm.stack.length !== stack.length) {
-                            vm.stack = stack;
+                for (var i=0; i<registeredFrameURLs.length; i++) {
+                    chrome.devtools.inspectedWindow.eval(
+                        "__CANJS_DEVTOOLS__.queuesStack()",
+                        { frameURL: registeredFrameURLs[i] },
+                        function(stack, isException) {
+                            if (stack) {
+                                if (!vm.stack || vm.stack.length !== stack.length) {
+                                    vm.stack = stack;
+                                }
+                            }
                         }
-                    });
+                    );
+                }
 
-                timeoutId = setTimeout(updateStack, POLLING_INTERVAL);
+                timeoutId = setTimeout(updateStack, 100);
             };
 
             updateStack();

--- a/viewmodel-editor/viewmodel-editor.js
+++ b/viewmodel-editor/viewmodel-editor.js
@@ -1,101 +1,14 @@
-// run an expression in the page
-var pageEval = chrome.devtools.inspectedWindow.eval;
+// URLs of all frames that have registered that they
+// have a global `can` present
+var registeredFrameURLs = [];
 
-var POLLING_INTERVAL = 100;
-
-// tostring a function and wrap in an IIFE so it can be evaled
-var iifeify = function(fn) {
-	var args = Array.prototype.slice.call(arguments, 1);
-    return "(" + fn.toString() + "(" +
-		args.map(function(arg) { return "'" + arg + "'"; }).join(", ") +
-	"))";
-};
-
-// helpers for working with the selected element (`$0`)
-var selectedElement = {
-    getElementWithViewModelData: function() {
-		var elementWithViewModel = (function getElementWithViewModel(el) {
-			el = el ? el : $0;
-			var vm = el[can.Symbol.for("can.viewModel")];
-			return vm ?
-				el :
-				el.parentNode ?
-				getElementWithViewModel(el.parentNode) :
-				undefined;
-		}());
-
-		var getViewModelData = function(el) {
-			var viewModel = can.viewModel(el);
-			var viewModelData = viewModel.serialize();
-			var viewModelKeys = can.Reflect.getOwnKeys( can.viewModel( el ) );
-
-			for (var i=0; i<viewModelKeys.length; i++) {
-				var key = viewModelKeys[i];
-				if (!viewModelData[ key ]) {
-					viewModelData[key] = can.Reflect.getKeyValue( viewModel, key );
-				}
-			}
-
-            var sortedViewModel = {};
-
-            Object.keys(viewModelData).sort().forEach(function(key) {
-                sortedViewModel[key] = viewModelData[key];
-            });
-
-            return sortedViewModel;
-		};
-
-        if (elementWithViewModel) {
-            return {
-				tagName: elementWithViewModel.tagName,
-                viewModel: getViewModelData( elementWithViewModel )
-            };
-        } else {
-            return {
-                tagName: $0.tagName
-            };
-        }
-    },
-
-    getData: function getData() {
-        return new Promise(function(resolve, reject) {
-            pageEval(iifeify( selectedElement.getElementWithViewModelData ), function(data, isException) {
-				if (isException) {
-                    reject(isException);
-                }
-
-                resolve(data);
-            });
-        });
-    },
-
-    setElementWithViewModelKeyValue: function(key, value) {
-		var elementWithViewModel = (function getElementWithViewModel(el) {
-			el = el ? el : $0;
-			var vm = el[can.Symbol.for("can.viewModel")];
-			return vm ?
-				el :
-				el.parentNode ?
-				getElementWithViewModel(el.parentNode) :
-				undefined;
-		}());
-
-		var viewModel = can.viewModel( elementWithViewModel );
-		can.Reflect.setKeyValue( viewModel, key, value );
-    },
-
-    setViewModelKeyValue: function setViewModelKeyValue(key, value) {
-        return new Promise(function(resolve, reject) {
-            pageEval(iifeify( selectedElement.setElementWithViewModelKeyValue, key, value ), function(data, isException) {
-				if (isException) {
-                    reject(isException);
-                }
-
-                resolve(data);
-            });
-        });
+// listen to messages from the injected-script
+// TODO - move this to index.js and pass registeredFrameURLs list to each sidebar
+chrome.runtime.onMessage.addListener(function(msg, sender) {
+    if (msg.type === "register") {
+        registeredFrameURLs.push(msg.frameURL);
     }
-};
+});
 
 can.Component.extend({
     tag: "canjs-devtools-viewmodel-editor",
@@ -113,31 +26,47 @@ can.Component.extend({
 
         viewModelData: "observable",
 
-        setKeyValue: selectedElement.setViewModelKeyValue,
+        setKeyValue: function() {
+        },
 
         connectedCallback() {
             var vm = this;
             var timeoutId;
 
             var getSelectedElementData = function() {
-                selectedElement.getData()
-                    .then(function(elementData) {
-                        can.Reflect.setKeyValue(vm, "tagName", elementData.tagName);
-
-                        if (vm.viewModelData) {
-                            if (elementData.viewModel) {
-                                can.Reflect.update(vm.viewModelData, elementData.viewModel);
-                            } else {
-                                can.Reflect.deleteKeyValue(vm, "viewModelData");
+                for (var i=0; i<registeredFrameURLs.length; i++) {
+                    chrome.devtools.inspectedWindow.eval(
+                        "__CANJS_DEVTOOLS__.getViewModelData($0)",
+                        { frameURL: registeredFrameURLs[i] },
+                        function(result, isException) {
+                            if (isException) {
+                                console.error(isException);
                             }
-                        } else {
-                            can.Reflect.setKeyValue(vm, "viewModelData", elementData.viewModel);
+
+                            if (!result) {
+                                return;
+                            }
+
+                            // if selected element changed, remove viewModel completely
+                            if (vm.tagName !== result.tagName) {
+                                can.Reflect.setKeyValue(vm, "tagName", result.tagName);
+                                can.Reflect.setKeyValue(vm, "viewModelData", result.viewModel);
+                            } else {
+                                if (vm.viewModelData) {
+                                    if (result.viewModel) {
+                                        can.Reflect.update(vm.viewModelData, result.viewModel);
+                                    } else {
+                                        can.Reflect.deleteKeyValue(vm, "viewModelData");
+                                    }
+                                } else {
+                                    can.Reflect.setKeyValue(vm, "viewModelData", result.viewModel);
+                                }
+                            }
                         }
-                    })
-                    .then(function(elementData) {
-                        // poll for changes
-                        timeoutId = setTimeout(getSelectedElementData, POLLING_INTERVAL);
-                    });
+                    );
+                }
+
+                timeoutId = setTimeout(getSelectedElementData, 100);
             };
 
             getSelectedElementData();


### PR DESCRIPTION
The basics of this are working for the ViewModel Editor and Bindings Graph. The queues tab is still not working for some reason I haven't figured out.

Also, the main thing remaining is error handling and cleanup:
- [ ] remove frames that aren't active anymore from all of the `frameURLs` lists
- [ ] somehow centralize the `update-frames` handlers so each panel doesn't need  to duplicate this code
- [x] display warnings when `can` or features of `can` (like `can-debug.getGraph` etc) don't exist
- [x] figure out why the binding graph isn't displayed on load
- [x] figure out why the Queues Stack tab isn't working with frames
- [ ] document the new architecture so other people can make changes