### PR TITLE
update getBreakpointEvalString to use viewModel symbol

### DIFF
--- a/canjs-devtools-helpers.mjs
+++ b/canjs-devtools-helpers.mjs
@@ -175,7 +175,7 @@ const helpers = {
             return { error: "Please select a component in order to create a mutation breakpoint for its ViewModel" };
         }
 
-        const vm = selectedComponent.viewModel;
+        const vm = selectedComponent[Symbol.for('can.viewModel')];
         const vmName = window.__CANJS_DEVTOOLS__.canReflect.getName(vm);
         let oldValue = ${observationExpression};
 

--- a/test/helpers-test.js
+++ b/test/helpers-test.js
@@ -282,33 +282,6 @@ describe("canjs-devtools-helpers", () => {
             });
         });
 
-        describe("can be created with StacheElement", () => {
-            it("hobbies.length", () => {
-                let devtoolsVM = new (DefineMap.extend("DevtoolsVM", {
-                    hobbies: { Default: DefineList }
-                }));
-
-                $0[Symbol.for('can.viewModel')] = devtoolsVM;
-
-                let str = helpers.getBreakpointEvalString({
-                    expression: "hobbies.length",
-                    debuggerStatement: "mock._debugger"
-                });
-                let breakpoint = eval( str );
-
-                assert.equal(breakpoint.expression, "DevtoolsVM{}.hobbies.length");
-                assert.equal(Reflect.getValue(breakpoint.observation), devtoolsVM.hobbies.length, "obs === hobbies.length");
-
-                Reflect.onValue(breakpoint.observation, () => {});
-
-                devtoolsVM.hobbies.push("skiing");
-                assert.equal(debuggerHitCount, 1, "debugger hit once");
-
-                devtoolsVM.hobbies.push("badminton");
-                assert.equal(debuggerHitCount, 2, "debugger hit again");
-            });
-        });
-
         describe("can be restored with expression", () => {
             beforeEach(() => {
                 const $0 = devtools.$0;

--- a/test/helpers-test.js
+++ b/test/helpers-test.js
@@ -129,7 +129,7 @@ describe("canjs-devtools-helpers", () => {
         let $0, devtools, debuggerHitCount, mock;
 
         beforeEach(() => {
-            $0 = { viewModel: {} };
+            $0 = { [Symbol.for('can.viewModel')]: {} };
 
             devtools = {
                 $0,
@@ -161,7 +161,7 @@ describe("canjs-devtools-helpers", () => {
                     hobbies: { Default: DefineList }
                 }));
 
-                $0.viewModel = devtoolsVM;
+                $0[Symbol.for('can.viewModel')] = devtoolsVM;
 
                 let str = helpers.getBreakpointEvalString({
                     expression: "hobbies.length",
@@ -186,7 +186,7 @@ describe("canjs-devtools-helpers", () => {
                     hobbies: { Default: DefineList }
                 }));
 
-                $0.viewModel = devtoolsVM;
+                $0[Symbol.for('can.viewModel')] = devtoolsVM;
 
                 let str = helpers.getBreakpointEvalString({
                     expression: "hobbies.length > 1",
@@ -215,7 +215,7 @@ describe("canjs-devtools-helpers", () => {
                     counter: { default: 2 }
                 }));
 
-                $0.viewModel = devtoolsVM;
+                $0[Symbol.for('can.viewModel')] = devtoolsVM;
 
                 let str = helpers.getBreakpointEvalString({
                     expression: "hobbies.length > counter",
@@ -258,7 +258,7 @@ describe("canjs-devtools-helpers", () => {
                     hobbies: { Type: DefineList }
                 }));
 
-                $0.viewModel = devtoolsVM;
+                $0[Symbol.for('can.viewModel')] = devtoolsVM;
 
                 let str = helpers.getBreakpointEvalString({
                     expression: "hobbies.length",
@@ -282,6 +282,33 @@ describe("canjs-devtools-helpers", () => {
             });
         });
 
+        describe("can be created with StacheElement", () => {
+            it("hobbies.length", () => {
+                let devtoolsVM = new (DefineMap.extend("DevtoolsVM", {
+                    hobbies: { Default: DefineList }
+                }));
+
+                $0[Symbol.for('can.viewModel')] = devtoolsVM;
+
+                let str = helpers.getBreakpointEvalString({
+                    expression: "hobbies.length",
+                    debuggerStatement: "mock._debugger"
+                });
+                let breakpoint = eval( str );
+
+                assert.equal(breakpoint.expression, "DevtoolsVM{}.hobbies.length");
+                assert.equal(Reflect.getValue(breakpoint.observation), devtoolsVM.hobbies.length, "obs === hobbies.length");
+
+                Reflect.onValue(breakpoint.observation, () => {});
+
+                devtoolsVM.hobbies.push("skiing");
+                assert.equal(debuggerHitCount, 1, "debugger hit once");
+
+                devtoolsVM.hobbies.push("badminton");
+                assert.equal(debuggerHitCount, 2, "debugger hit again");
+            });
+        });
+
         describe("can be restored with expression", () => {
             beforeEach(() => {
                 const $0 = devtools.$0;
@@ -300,7 +327,7 @@ describe("canjs-devtools-helpers", () => {
                     hobbies: { Default: DefineList }
                 }));
 
-                $0.viewModel = devtoolsVM;
+                $0[Symbol.for('can.viewModel')] = devtoolsVM;
 
                 let str = helpers.getBreakpointEvalString({
                     expression: "DevtoolsVM{}.hobbies.length",


### PR DESCRIPTION
Change the `getBreakpointEvalString` eval string to use the `Symbol.for('can.viewModel')` instead of `vm.viewModel`.