### PR TITLE
Upgrade to Can 6

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,11 @@
+; Unix-style newlines
+[*]
+end_of_line = LF
+indent_style = tab
+trim_trailing_whitespace = false
+insert_final_newline = true
+indent_size = 2
+
+[{package.json,*.yml,*.json}]
+indent_style = space
+indent_size = 2

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,0 +1,19 @@
+module.exports = {
+	env: {
+		browser: true,
+		es6: true,
+		mocha: true
+	},
+	extends: "eslint:recommended",
+	globals: {
+		Atomics: "readonly",
+		SharedArrayBuffer: "readonly",
+		chrome: "readonly",
+		inspect: "readonly"
+	},
+	parserOptions: {
+		ecmaVersion: 2018,
+		sourceType: "module"
+	},
+	rules: {}
+};

--- a/bindings-graph/index.html
+++ b/bindings-graph/index.html
@@ -1,16 +1,26 @@
-<!doctype html>
-<html>
-    <head>
-        <link rel="stylesheet" type="text/css" href="../node_modules/can-devtools-components/dist/can-devtools-components.css">
-        <style>
-            bindings-graph div {
-                height: 90%;
-                width: 98%;
-            }
-        </style>
-    </head>
-    <body>
-        <canjs-devtools-bindings-graph></canjs-devtools-bindings-graph>
-        <script type="module" src="bindings-graph.mjs"></script>
-    </body>
+<!DOCTYPE html>
+<html lang="en">
+	<head>
+		<meta charset="UTF-8" />
+		<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+		<meta http-equiv="X-UA-Compatible" content="ie=edge" />
+		<title>canjs-devtools-bindings-graph</title>
+		<link
+			rel="stylesheet"
+			type="text/css"
+			href="../node_modules/can-devtools-components/dist/can-devtools-components.css"
+		/>
+		<style>
+			bindings-graph div {
+				height: 90%;
+				width: 98%;
+			}
+		</style>
+	</head>
+	<body>
+		<body>
+			<canjs-devtools-bindings-graph></canjs-devtools-bindings-graph>
+			<script type="module" src="bindings-graph.mjs"></script>
+		</body>
+	</body>
 </html>

--- a/canjs-devtools-background.js
+++ b/canjs-devtools-background.js
@@ -2,87 +2,87 @@ const frames = {};
 const breakpointsByFrameURL = {};
 
 function updateFrameURLs() {
-    const frameURLs = Object.keys(frames);
+	const frameURLs = Object.keys(frames);
 
-    // send updated list of frames to canjs-devtools-helpers.mjs
-    chrome.runtime.sendMessage({
-        type: "__CANJS_DEVTOOLS_UPDATE_FRAMES__",
-        frames: frames
-    });
+	// send updated list of frames to canjs-devtools-helpers.mjs
+	chrome.runtime.sendMessage({
+		type: "__CANJS_DEVTOOLS_UPDATE_FRAMES__",
+		frames: frames
+	});
 
-    // if there are active frames, update the icon/popup
-    // to the blue CanJS logo when the page is using CanJS
-    for (let i=0; i<frameURLs.length; i++) {
-        chrome.browserAction.setPopup({
-            tabId: frames[ frameURLs[i] ].tabId,
-            popup: "popups/can.html"
-        });
+	// if there are active frames, update the icon/popup
+	// to the blue CanJS logo when the page is using CanJS
+	for (let i = 0; i < frameURLs.length; i++) {
+		chrome.browserAction.setPopup({
+			tabId: frames[frameURLs[i]].tabId,
+			popup: "popups/can.html"
+		});
 
-        chrome.browserAction.setIcon({
-            tabId: frames[ frameURLs[i] ].tabId,
-            path: {
-                "16": "images/canjs-16-enabled.png"
-            }
-        });
-    }
+		chrome.browserAction.setIcon({
+			tabId: frames[frameURLs[i]].tabId,
+			path: {
+				"16": "images/canjs-16-enabled.png"
+			}
+		});
+	}
 }
 
 function updateBreakpointsForURL(url) {
-    chrome.runtime.sendMessage({
-        type: "__CANJS_DEVTOOLS_UPDATE_BREAKPOINTS__",
-        breakpoints: breakpointsByFrameURL[url]
-    });
+	chrome.runtime.sendMessage({
+		type: "__CANJS_DEVTOOLS_UPDATE_BREAKPOINTS__",
+		breakpoints: breakpointsByFrameURL[url]
+	});
 }
 
 function getUrlFromPort(port) {
-    return port.sender.url.split("#")[0];
+	return port.sender.url.split("#")[0];
 }
 
 chrome.runtime.onConnect.addListener(function(port) {
-    // listen for messages from canjs-devtools-content-script.js
-    if (port.name === "canjs-devtools") {
-        // and update frames map
-        port.onMessage.addListener(function messageHandler(msg, port) {
-            const url = getUrlFromPort(port);
-            const { type, data } = msg;
+	// listen for messages from canjs-devtools-content-script.js
+	if (port.name === "canjs-devtools") {
+		// and update frames map
+		port.onMessage.addListener(function messageHandler(msg, port) {
+			const url = getUrlFromPort(port);
+			const { type, data } = msg;
 
-            switch(type) {
-                case "page-loaded":
-                    // if this is a new frame being registered by the
-                    // injected-script, add its url to the frames list
-                    // and update the frames lists in all helpers scripts
-                    // that have executed already
-                    frames[url] = {
-                        frameURL: url,
-                        tabId: port.sender.tab.id
-                    };
+			switch (type) {
+				case "page-loaded":
+					// if this is a new frame being registered by the
+					// injected-script, add its url to the frames list
+					// and update the frames lists in all helpers scripts
+					// that have executed already
+					frames[url] = {
+						frameURL: url,
+						tabId: port.sender.tab.id
+					};
 
-                    updateFrameURLs();
+					updateFrameURLs();
 
-                    // also, send any breakpoints previously created for this URL
-                    updateBreakpointsForURL(url);
+					// also, send any breakpoints previously created for this URL
+					updateBreakpointsForURL(url);
 
-                    break;
-                case "canjs-devtools-loaded":
-                    // if the helpers script is executing for the first time,
-                    // update the frames lists
-                    updateFrameURLs();
-                    break;
-                case "set-breakpoints":
-                    breakpointsByFrameURL[url] = data;
-                    break;
-            }
-        });
+					break;
+				case "canjs-devtools-loaded":
+					// if the helpers script is executing for the first time,
+					// update the frames lists
+					updateFrameURLs();
+					break;
+				case "set-breakpoints":
+					breakpointsByFrameURL[url] = data;
+					break;
+			}
+		});
 
-        // remove frame when page or frame is closed
-        port.onDisconnect.addListener(function disconnectHandler(port) {
-            const url = getUrlFromPort(port);
+		// remove frame when page or frame is closed
+		port.onDisconnect.addListener(function disconnectHandler(port) {
+			const url = getUrlFromPort(port);
 
-            if (frames[url]) {
-                delete frames[url];
-            }
+			if (frames[url]) {
+				delete frames[url];
+			}
 
-            updateFrameURLs();
-        });
-    }
+			updateFrameURLs();
+		});
+	}
 });

--- a/canjs-devtools-content-script.js
+++ b/canjs-devtools-content-script.js
@@ -9,9 +9,9 @@ document.addEventListener("__CANJS_DEVTOOLS_EVENT__", function(ev) {
 // inject script into page to add __CANJS_DEVTOOLS__ namespace to window
 // and register page with devtools extension
 function injectScript(el) {
-    var s = document.createElement("script");
-    s.src = chrome.extension.getURL("canjs-devtools-injected-script.js");
-    el.appendChild(s);
+	var s = document.createElement("script");
+	s.src = chrome.extension.getURL("canjs-devtools-injected-script.js");
+	el.appendChild(s);
 }
 
-injectScript( document.documentElement );
+injectScript(document.documentElement);

--- a/canjs-devtools-helpers.mjs
+++ b/canjs-devtools-helpers.mjs
@@ -196,12 +196,9 @@ const helpers = {
 						const newValue = ${observationExpression};
 						${
 							isBooleanExpression
-								? `if (newValue == true && oldValue != true) {
-								queues.logStack();
-								${debuggerStatement};
-						}`
+								? `if (newValue == true && oldValue != true) { queues.logStack(); ${debuggerStatement}; }`
 								: `queues.logStack();
-						${debuggerStatement};`
+							${debuggerStatement};`
 						}
 						oldValue = newValue;
 

--- a/canjs-devtools-helpers.mjs
+++ b/canjs-devtools-helpers.mjs
@@ -1,231 +1,240 @@
 const helpers = {
-    frameChangeHandlers: [],
+	frameChangeHandlers: [],
 
-    onFrameChange(fn) {
-      this.frameChangeHandlers.push(fn);
-    },
+	onFrameChange(fn) {
+		this.frameChangeHandlers.push(fn);
+	},
 
-    offFrameChange(fn) {
-      const index = this.frameChangeHandlers.indexOf(fn);
-      if (index > -1) {
-        this.frameChangeHandlers.splice(index, 1);
-      }
-    },
+	offFrameChange(fn) {
+		const index = this.frameChangeHandlers.indexOf(fn);
+		if (index > -1) {
+			this.frameChangeHandlers.splice(index, 1);
+		}
+	},
 
-    runFrameChangeHandlers() {
-      // copy handlers to new array
-      // since calling the handlers will add to the original array
-      const handlers = this.frameChangeHandlers.slice(0);
+	runFrameChangeHandlers() {
+		// copy handlers to new array
+		// since calling the handlers will add to the original array
+		const handlers = this.frameChangeHandlers.slice(0);
 
-      // reset handlers
-      this.frameChangeHandlers = [];
+		// reset handlers
+		this.frameChangeHandlers = [];
 
-      // call handlers in new array
-      for (let handler of handlers) {
-        handler();
-      }
-    },
+		// call handlers in new array
+		for (let handler of handlers) {
+			handler();
+		}
+	},
 
-    // URLs of all frames that have registered that they
-    // have a global `can` present
-    _registeredFrames: {},
+	// URLs of all frames that have registered that they
+	// have a global `can` present
+	_registeredFrames: {},
 
-    get registeredFrames() {
-      return this._registeredFrames;
-    },
+	get registeredFrames() {
+		return this._registeredFrames;
+	},
 
-    set registeredFrames(frames) {
-      this._registeredFrames = frames;
-      this.runFrameChangeHandlers();
-    },
+	set registeredFrames(frames) {
+		this._registeredFrames = frames;
+		this.runFrameChangeHandlers();
+	},
 
-    // breakpoints loaded from background script when page is loaded
-    storedBreakpoints: [],
+	// breakpoints loaded from background script when page is loaded
+	storedBreakpoints: [],
 
-    runDevtoolsFunction(options) {
-        const timeoutIds = [];
+	runDevtoolsFunction(options) {
+		const timeoutIds = [];
 
-        const runDevtoolsFunctionForUrl = (url) => {
-            const refreshDataForThisUrl = () => {
-                if (options.refreshInterval) {
-                    const timeoutId = setTimeout(() => {
-                        runDevtoolsFunctionForUrl(url);
-                    }, options.refreshInterval);
+		const runDevtoolsFunctionForUrl = url => {
+			const refreshDataForThisUrl = () => {
+				if (options.refreshInterval) {
+					const timeoutId = setTimeout(() => {
+						runDevtoolsFunctionForUrl(url);
+					}, options.refreshInterval);
 
-                    timeoutIds.push(timeoutId);
-                }
-            };
+					timeoutIds.push(timeoutId);
+				}
+			};
 
-            if (helpers.registeredFrames[url]) {
-                chrome.devtools.inspectedWindow.eval(
-                    `typeof __CANJS_DEVTOOLS__ === 'object' && __CANJS_DEVTOOLS__.${options.fn ? options.fn() : options.fnString}`,
-                    { frameURL: url },
-                    (result, exception) => {
-                        if (exception) {
-                            refreshDataForThisUrl();
-                            return;
-                        }
+			if (helpers.registeredFrames[url]) {
+				chrome.devtools.inspectedWindow.eval(
+					`typeof __CANJS_DEVTOOLS__ === 'object' && __CANJS_DEVTOOLS__.${
+						options.fn ? options.fn() : options.fnString
+					}`,
+					{ frameURL: url },
+					(result, exception) => {
+						if (exception) {
+							refreshDataForThisUrl();
+							return;
+						}
 
-                        if (options.success) {
-                            options.success(result);
-                        }
+						if (options.success) {
+							options.success(result);
+						}
 
-                        refreshDataForThisUrl();
-                    }
-                );
-            } else {
-                if (options.success) {
-                    // if there were frames before, and there are no frames now
-                    // reset data to the "empty" state
-                    options.success({
-                        status: "success",
-                        detail: {}
-                    });
-                }
-            }
-        };
+						refreshDataForThisUrl();
+					}
+				);
+			} else {
+				if (options.success) {
+					// if there were frames before, and there are no frames now
+					// reset data to the "empty" state
+					options.success({
+						status: "success",
+						detail: {}
+					});
+				}
+			}
+		};
 
-        // teardown function
-        const teardown = () => {
-            timeoutIds.forEach((id) => {
-                clearTimeout(id);
-            });
+		// teardown function
+		const teardown = () => {
+			timeoutIds.forEach(id => {
+				clearTimeout(id);
+			});
 
-            this.offFrameChange(frameChangeHandler);
-        };
+			this.offFrameChange(frameChangeHandler);
+		};
 
-        const frameChangeHandler = () => {
-          // remove old `refreshDataForThisUrl` timeouts
-          teardown();
+		const frameChangeHandler = () => {
+			// remove old `refreshDataForThisUrl` timeouts
+			teardown();
 
-          // run function for all new frames
-          runDevtoolsFunctionForAllUrls();
-        };
+			// run function for all new frames
+			runDevtoolsFunctionForAllUrls();
+		};
 
-        const runDevtoolsFunctionForAllUrls = () => {
-            const frameURLs = Object.keys(helpers.registeredFrames);
+		const runDevtoolsFunctionForAllUrls = () => {
+			const frameURLs = Object.keys(helpers.registeredFrames);
 
-            if (frameURLs.length) {
-                frameURLs.forEach((url) => {
-                    runDevtoolsFunctionForUrl(url);
-                });
-            }
+			if (frameURLs.length) {
+				frameURLs.forEach(url => {
+					runDevtoolsFunctionForUrl(url);
+				});
+			}
 
-            // when a frame is added or removed
-            // remove the old refresh handlers
-            // and re-create them
-            this.onFrameChange(frameChangeHandler);
-        };
+			// when a frame is added or removed
+			// remove the old refresh handlers
+			// and re-create them
+			this.onFrameChange(frameChangeHandler);
+		};
 
-        runDevtoolsFunctionForAllUrls();
+		runDevtoolsFunctionForAllUrls();
 
-        return teardown;
-    },
+		return teardown;
+	},
 
-    getSafeKey(key, prependStr) {
-        const parts = key.split(".");
-        let last = "";
+	getSafeKey(key, prependStr) {
+		const parts = key.split(".");
+		let last = "";
 
-        const safeParts = parts.reduce((newParts, key) => {
-            last = last ? `${last}.${key}` : `${prependStr}.${key}`;
-            newParts.push(last);
-            return newParts;
-        }, []);
+		const safeParts = parts.reduce((newParts, key) => {
+			last = last ? `${last}.${key}` : `${prependStr}.${key}`;
+			newParts.push(last);
+			return newParts;
+		}, []);
 
-        if (parts.length > 1) {
-            return `(${safeParts.join(" && ")})`;
-        } else {
-            return safeParts.join(" && ");
-        }
-    },
+		if (parts.length > 1) {
+			return `(${safeParts.join(" && ")})`;
+		} else {
+			return safeParts.join(" && ");
+		}
+	},
 
-    getObservationExpression(expression) {
-        return expression.replace(/(^|\s|=|>|<|!|\/|%|\+|-|\*|&|\(|\)|~|\?|,|\[|\])([A-Za-z_:.]*)/g, (match, delimiter, key) => {
-            return `${delimiter}${key ? this.getSafeKey(key, "vm") : ""}`;
-        });
-    },
+	getObservationExpression(expression) {
+		return expression.replace(
+			/(^|\s|=|>|<|!|\/|%|\+|-|\*|&|\(|\)|~|\?|,|\[|\])([A-Za-z_:.]*)/g,
+			(match, delimiter, key) => {
+				return `${delimiter}${key ? this.getSafeKey(key, "vm") : ""}`;
+			}
+		);
+	},
 
-    getDisplayExpression(expression) {
-        return expression.replace(/(^|\s|=|>|<|!|\/|%|\+|-|\*|&|\(|\)|~|\?|,|\[|\])([A-Za-z_])/g, (match, delimiter, prop) => {
-            return `${delimiter}\$\{vmName\}.${prop}`;
-        });
-    },
+	getDisplayExpression(expression) {
+		return expression.replace(
+			/(^|\s|=|>|<|!|\/|%|\+|-|\*|&|\(|\)|~|\?|,|\[|\])([A-Za-z_])/g,
+			(match, delimiter, prop) => {
+				return `${delimiter}\$\{vmName\}.${prop}`;
+			}
+		);
+	},
 
-    isBooleanExpression(expression) {
-        return /[!=<>]/.test(expression);
-    },
+	isBooleanExpression(expression) {
+		return /[!=<>]/.test(expression);
+	},
 
-    getBreakpointEvalString({
-        expression,
-        enabled = true,
-        observationExpression = this.getObservationExpression(expression),
-        selectedComponentStatement = "window.__CANJS_DEVTOOLS__.$0",
-        displayExpression = this.getDisplayExpression(expression),
-        pathStatement = "window.__CANJS_DEVTOOLS__.pathOf$0",
-        debuggerStatement = "debugger" // overwritable for testing
-    }) {
-        const isBooleanExpression = this.isBooleanExpression(observationExpression);
+	getBreakpointEvalString({
+		expression,
+		enabled = true,
+		observationExpression = this.getObservationExpression(expression),
+		selectedComponentStatement = "window.__CANJS_DEVTOOLS__.$0",
+		displayExpression = this.getDisplayExpression(expression),
+		pathStatement = "window.__CANJS_DEVTOOLS__.pathOf$0",
+		debuggerStatement = "debugger" // overwritable for testing
+	}) {
+		const isBooleanExpression = this.isBooleanExpression(observationExpression);
 
-        return `(function() {
-        const Observation = window.__CANJS_DEVTOOLS__.canObservation;
-        const queues = window.__CANJS_DEVTOOLS__.canQueues;
-        const selectedComponent = ${selectedComponentStatement};
+		return `(function() {
+				const Observation = window.__CANJS_DEVTOOLS__.canObservation;
+				const queues = window.__CANJS_DEVTOOLS__.canQueues;
+				const selectedComponent = ${selectedComponentStatement};
 
-        if (!selectedComponent) {
-            return { error: "Please select a component in order to create a mutation breakpoint for its ViewModel" };
-        }
+				if (!selectedComponent) {
+						return { error: "Please select a component in order to create a mutation breakpoint for its ViewModel" };
+				}
 
-        const vm = selectedComponent[Symbol.for('can.viewModel')];
-        const vmName = window.__CANJS_DEVTOOLS__.canReflect.getName(vm);
-        let oldValue = ${observationExpression};
+				const vm = selectedComponent[Symbol.for('can.viewModel')];
+				const vmName = window.__CANJS_DEVTOOLS__.canReflect.getName(vm);
+				let oldValue = ${observationExpression};
 
-        const observation = new Observation(() => {
-            return ${observationExpression};
-        });
-        const origDependencyChange = observation.dependencyChange;
+				const observation = new Observation(() => {
+						return ${observationExpression};
+				});
+				const origDependencyChange = observation.dependencyChange;
 
-        observation.dependencyChange = function() {
-            const newValue = ${observationExpression};
-            ${ isBooleanExpression ?
-            `if (newValue == true && oldValue != true) {
-                queues.logStack();
-                ${debuggerStatement};
-            }` :
-            `queues.logStack();
-            ${debuggerStatement};`
-            }
-            oldValue = newValue;
+				observation.dependencyChange = function() {
+						const newValue = ${observationExpression};
+						${
+							isBooleanExpression
+								? `if (newValue == true && oldValue != true) {
+								queues.logStack();
+								${debuggerStatement};
+						}`
+								: `queues.logStack();
+						${debuggerStatement};`
+						}
+						oldValue = newValue;
 
-            return origDependencyChange.apply(this, arguments);
-        };
+						return origDependencyChange.apply(this, arguments);
+				};
 
-        return {
-            expression: \`${displayExpression}\`,
-            observation: observation,
-            observationExpression: \`${observationExpression}\`,
-            path: ${pathStatement},
-            enabled: ${enabled}
-        };
-    }())`
-    }
+				return {
+						expression: \`${displayExpression}\`,
+						observation: observation,
+						observationExpression: \`${observationExpression}\`,
+						path: ${pathStatement},
+						enabled: ${enabled}
+				};
+		}())`;
+	}
 };
 
 if (typeof chrome === "object" && chrome.runtime && chrome.runtime.onMessage) {
-    // listen to messages from the background script
-    chrome.runtime.onMessage.addListener((msg, sender) => {
-        switch(msg.type) {
-            case  "__CANJS_DEVTOOLS_UPDATE_FRAMES__":
-                helpers.registeredFrames = msg.frames;
-                break;
-            case  "__CANJS_DEVTOOLS_UPDATE_BREAKPOINTS__":
-                helpers.storedBreakpoints = msg.breakpoints;
-                break;
-        }
-    });
+	// listen to messages from the background script
+	chrome.runtime.onMessage.addListener((msg, sender) => {
+		switch (msg.type) {
+			case "__CANJS_DEVTOOLS_UPDATE_FRAMES__":
+				helpers.registeredFrames = msg.frames;
+				break;
+			case "__CANJS_DEVTOOLS_UPDATE_BREAKPOINTS__":
+				helpers.storedBreakpoints = msg.breakpoints;
+				break;
+		}
+	});
 
-    // when a devtools panel is opened, request an updated list of frames
-    var port = chrome.runtime.connect({ name: "canjs-devtools" });
-    port.postMessage({ type: "canjs-devtools-loaded" });
+	// when a devtools panel is opened, request an updated list of frames
+	var port = chrome.runtime.connect({ name: "canjs-devtools" });
+	port.postMessage({ type: "canjs-devtools-loaded" });
 }
 
 export default helpers;

--- a/canjs-devtools-injected-script.js
+++ b/canjs-devtools-injected-script.js
@@ -1,607 +1,639 @@
 (function() {
-    // CanJS modules set up by register function
-    let viewModelSymbol,
-        getOwnKeysSymbol,
-        canObservation,
-        canQueues,
-        canReflect,
-        formatGraph,
-        getGraph,
-        mergeDeep;
-
-    // component tree variables
-    let nextNodeId = 0;
-    let componentTree = [];
-    const nodeToIdMap = new WeakMap();
-    const nodeToElementMap = new WeakMap();
-
-    // breakpoints variables
-    let nextBreakpointId = 0;
-    const breakpoints = [];
-    const breakpointToObservableMap = new WeakMap();
-    const noop = () => {};
-
-    // helper functions
-    const getObjAtKey = (obj, key) => {
-        if (!key) {
-            return obj;
-        }
-
-        const parts = key.split(".");
-
-        return parts.reduce((parent, key) => {
-            return canReflect.getKeyValue(parent, key);
-        }, obj);
-    };
-
-    const getLastParent = (obj, key) => {
-        return getObjAtKey(obj, key.split(".").slice(0, -1).join("."));
-    };
-
-    const getLastKey = (path) => {
-        return path.split(".").pop();
-    };
-
-    const getIndexOfItemInArrayWithId = (arr, id) => {
-        let index = -1;
-
-        arr.some((item, i) => {
-            if (item.id === id) {
-                index = i;
-                return true;
-            }
-        });
-
-        return index;
-    };
-
-    const sendEventToBackgroundScript = (detail) =>{
-        const registrationEvent = new CustomEvent("__CANJS_DEVTOOLS_EVENT__", { detail });
-        document.dispatchEvent(registrationEvent);
-    };
-
-    // add path information to component tree node and its children (recursively)
-    const addPaths = (node, index, parentPath) => {
-        let path = parentPath ? `${parentPath}.children.${index}` : `${index}`;
-        return Object.assign(node, {
-            path,
-            children: node.children.map((node, index) =>
-                addPaths(node, index, path)
-            )
-        });
-    };
-
-    // expose devtools namespace on the window
-    window.__CANJS_DEVTOOLS__ = {
-        // flag indicating whether register has been called
-        registered: false,
-
-        // element selected in CanJS Devtools Panel
-        $0: null,
-
-        // path of element selected
-        pathOf$0: null,
-
-        /*
-         * methods called by devtools panels
-         */
-        register(can) {
-            viewModelSymbol = can.Symbol.for("can.viewModel");
-            getOwnKeysSymbol = can.Symbol.for("can.getOwnKeys");
-            canObservation = can.Observation;
-            canQueues = can.queues;
-            canReflect = can.Reflect;
-            formatGraph = can.formatGraph;
-            getGraph = can.getGraph;
-            mergeDeep = can.mergeDeep;
-
-            // register page so inspectedWindow.eval can call devtools functions in this frame
-            sendEventToBackgroundScript({ type: "page-loaded" });
-
-            this.registered = true;
-        },
-
-        getViewModelData(el, options) {
-            // if $0 is not in this frame, el will be null
-            if (!el) {
-                return this.makeIgnoreResponse("$0 is not in this frame");
-            }
-
-            // handle the user having devtools open and navigating to a page without can
-            if (!this.registered) {
-                return this.makeErrorResponse(this.NO_CAN_MSG);
-            }
-
-            const elementWithViewModel = this.getNearestElementWithViewModel(el);
-
-            if (!elementWithViewModel) {
-                return this.makeIgnoreResponse("&lt;" + el.tagName.toLowerCase() + "&gt; does not have a viewModel");
-            }
-
-            const viewModel = elementWithViewModel[viewModelSymbol];
-            const { viewModelData, typeNames, messages, undefineds } = this.getSerializedViewModelData(viewModel, options);
-
-            return this.makeSuccessResponse({
-                tagName: this.getUniqueTagName(elementWithViewModel),
-                viewModelData,
-                typeNames,
-                messages,
-                undefineds
-            });
-        },
-
-        updateViewModel(el, patches) {
-            // if $0 is not in this frame, el will be null
-            if (!el) {
-                return this.makeIgnoreResponse("$0 is not in this frame");
-            }
-
-            // handle the user having devtools open and navigating to a page without can
-            if (!this.registered) {
-                return this.makeErrorResponse(this.NO_CAN_MSG);
-            }
-
-            const elementWithViewModel = this.getNearestElementWithViewModel(el);
-
-            if (elementWithViewModel) {
-                const viewModel = elementWithViewModel[viewModelSymbol];
-                let parentObj, lastKey;
-
-                patches.forEach(({ type, key, value, index, deleteCount, insert }) => {
-                    switch(type) {
-                        case "add":
-                        case "set":
-                            parentObj = getLastParent(viewModel, key);
-                            lastKey = getLastKey(key);
-                            canReflect.setKeyValue(parentObj, lastKey, value);
-                            break;
-                        case "delete":
-                            parentObj = getLastParent(viewModel, key);
-                            lastKey = getLastKey(key);
-                            canReflect.deleteKeyValue(parentObj, lastKey);
-                            break;
-                        case "splice":
-                            parentObj = getObjAtKey(viewModel, key);
-                            parentObj.splice(index, deleteCount, ...insert);
-                            break;
-                    }
-                });
-            }
-        },
-
-        getBindingsGraphData(el, key) {
-            // if $0 is not in this frame, el will be null
-            if (!el) {
-                return this.makeIgnoreResponse("$0 is not in this frame");
-            }
-
-            // handle the user having devtools open and navigating to a page without can
-            if (!this.registered) {
-                return this.makeErrorResponse(this.NO_CAN_MSG);
-            }
-
-            const hasViewModel = el[viewModelSymbol];
-            const obj = hasViewModel ? hasViewModel : el;
-
-            const graphData = formatGraph( getGraph(obj, key) );
-
-            return this.makeSuccessResponse({
-                availableKeys: hasViewModel ? this.getViewModelKeys(obj) : this.getElementKeys(el),
-                selectedObj: "<" + el.tagName.toLowerCase() + ">" + (hasViewModel ? ".viewModel" : ""),
-                graphData: graphData
-            });
-        },
-
-        queuesStack() {
-            if (!this.registered) {
-                // don't show an error for this because unlike ViewModel and Graph functions,
-                // this can't check if it is the correct frame by using $0.
-                // So just assume it's not the correct frame if register hasn't been called.
-                return this.makeIgnoreResponse(this.NO_CAN_MSG);
-            }
-
-            const stack = canQueues.stack();
-
-            return this.makeSuccessResponse({
-                frameURL: window.location.href,
-
-                stack: stack.map((task) => {
-                    return {
-                        queue: task.meta && task.meta.stack.name,
-                        context: canReflect.getName(task.context),
-                        functionName: canReflect.getName(task.fn),
-                        metaLog: task.meta && task.meta.log && task.meta.log.join(" "),
-                        metaReasonLog: task.meta && task.meta.reasonLog && task.meta.reasonLog.join(" ")
-                    };
-                })
-            });
-        },
-
-        inspectTask(index) {
-            if (!this.registered) {
-                return this.makeErrorResponse(this.NO_CAN_MSG);
-            }
-
-            const stack = canQueues.stack();
-
-            if (stack && stack[index] && stack[index].fn) {
-                inspect(stack[index].fn);
-            }
-        },
-
-        getComponentTreeData() {
-            if (!this.registered) {
-                // don't show an error for this because unlike ViewModel and Graph functions,
-                // this can't check if it is the correct frame by using $0.
-                // So just assume it's not the correct frame if register hasn't been called.
-                return this.makeIgnoreResponse(this.NO_CAN_MSG);
-            }
-
-            // cache componetTree so it can be used to find nodes by Id
-            componentTree = this.getComponentTreeDataForNode({
-                el: document.body,
-                selectedComponent: this.getNearestElementWithViewModel(window.$0)
-            }).map((node, index) => addPaths(node, index));
-
-            return this.makeSuccessResponse({
-                tree: componentTree
-            });
-        },
-
-        getComponentById(id) {
-            const node = this.getNodeById(id);
-            return nodeToElementMap.get(node);
-        },
-
-        selectComponentById(id) {
-            const node = this.getNodeById(id);
-            this.$0 = nodeToElementMap.get(node);
-            this.pathOf$0 = node.path;
-        },
-
-        getBreakpoints() {
-            return this.makeSuccessResponse({
-                breakpoints
-            });
-        },
-
-        addBreakpoint({ expression, observation, observationExpression, error, enabled = true, path }) {
-            if (error) {
-                return this.makeErrorResponse(error);
-            }
-
-            // serializable data only
-            const breakpoint = {
-                id: nextBreakpointId++,
-                expression,
-                observationExpression,
-                enabled,
-                path
-            };
-
-            breakpoints.push(breakpoint);
-
-            // send updated list of breakpoints to background script
-            sendEventToBackgroundScript({
-                type: "set-breakpoints",
-                data: breakpoints
-            });
-
-            if (observation) {
-                Object.defineProperty(observation.dependencyChange, "name", {
-                    value: `${expression} debugger`
-                });
-
-                if (enabled) {
-                    canReflect.onValue(observation, noop);
-                }
-
-                breakpointToObservableMap.set(
-                    breakpoint,
-                    observation
-                );
-            }
-
-            return this.getBreakpoints();
-        },
-
-        toggleBreakpoint(id) {
-            const index = getIndexOfItemInArrayWithId(breakpoints, id);
-            const breakpoint = breakpoints[index];
-            breakpoint.enabled = !breakpoint.enabled;
-
-            // send updated list of breakpoints to background script
-            sendEventToBackgroundScript({
-                type: "set-breakpoints",
-                data: breakpoints
-            });
-
-            const observation = breakpointToObservableMap.get(breakpoint);
-            if (observation) {
-                if (breakpoint.enabled) {
-                    canReflect.onValue(observation, noop);
-                } else {
-                    canReflect.offValue(observation, noop);
-                }
-            }
-
-            return this.getBreakpoints();
-        },
-
-        deleteBreakpoint(id) {
-            const index = getIndexOfItemInArrayWithId(breakpoints, id);
-            const breakpoint = breakpoints[index];
-            const observation = breakpointToObservableMap.get(breakpoint);
-            if (observation) {
-                canReflect.offValue(observation);
-            }
-            breakpoints.splice(index, 1);
-
-            // send updated list of breakpoints to background script
-            sendEventToBackgroundScript({
-                type: "set-breakpoints",
-                data: breakpoints
-            });
-
-            return this.getBreakpoints();
-        },
-
-        /*
-         * methods used to build responses
-         */
-        makeResponse(status, detail) {
-            return {
-                status: status,
-                detail: detail
-            };
-        },
-
-        makeIgnoreResponse(detail) {
-            return this.makeResponse("ignore", detail);
-        },
-
-        makeErrorResponse(detail) {
-            return this.makeResponse("error", detail);
-        },
-
-        makeSuccessResponse(detail) {
-            return this.makeResponse("success", detail);
-        },
-
-        NO_CAN_MSG: 'CanJS was not found on this page. If it is using CanJS, see the <a target="_blank" href="https://canjs.com/doc/guides/debugging.html#InstallingCanJSDevtools">installation instructions</a>.',
-
-        /*
-         * helper methods
-         */
-        getNearestElementWithViewModel(el) {
-            if (!el) {
-                return undefined;
-            }
-
-            const viewModel = el[viewModelSymbol];
-            return viewModel ?
-                    el :
-                    el.parentNode ?
-                        this.getNearestElementWithViewModel(el.parentNode) :
-                        undefined;
-        },
-
-        getSerializedViewModelData(viewModel, { expandedKeys = [] } = {}, parentPath = "") {
-            const viewModelKeys = this.getViewModelKeys(viewModel);
-            const viewModelData = {};
-            const typeNames = {};
-            const messages = {};
-            const undefineds = [];
-
-            if (viewModelKeys.length === 0) {
-                const type = canReflect.isObservableLike(viewModel) ?
-                    (canReflect.isMoreListLikeThanMapLike(viewModel) ? "List" : "Map") :
-                    Array.isArray(viewModel) ? "Array" : "Object";
-
-                messages[parentPath] = { type: "info", message: `${type} is empty` };
-            }
-
-            for (let i=0; i<viewModelKeys.length; i++) {
-                let key = viewModelKeys[i];
-                let path = `${parentPath ? parentPath + "." : ""}${key}`;
-                let value;
-                try {
-                    value = canReflect.getKeyValue(viewModel, key);
-                } catch(e) {
-                    // handle non-serializable values (such as recursive and circular structures)
-                    value = {};
-
-                    // add error message for key
-                    messages[path] = {
-                        type: "error",
-                        message: 'Error getting value of "' + path + '": ' + e.message
-                    };
-                }
-
-                // don't serialize functions
-                if (typeof value === "function") {
-                    viewModelData[key] = {};
-                    typeNames[path] = "function";
-                    messages[path] = {
-                        type: "info",
-                        message: value.toString()
-                    };
-                    continue;
-                }
-
-                if (value === null) {
-                    viewModelData[key] = null;
-                    continue;
-                }
-
-                if (value === undefined) {
-                    undefineds.push(path);
-                }
-
-                if (typeof value === "object") {
-                    viewModelData[key] = {};
-                    typeNames[path] = canReflect.getName(value);
-
-                    if (value instanceof Element) {
-                        messages[path] = {
-                            type: "info",
-                            message: "CanJS Devtools does not expand HTML Elements"
-                        };
-                        continue;
-                    }
-
-                    // get serialized data for children of expanded keys
-                    if (expandedKeys.indexOf(path) !== -1) {
-                        let {
-                            viewModelData: childViewModelData,
-                            typeNames: childNames,
-                            messages: childMessages,
-                            undefineds: childUndefineds
-                        } = this.getSerializedViewModelData(value, { expandedKeys }, path );
-
-                        viewModelData[key] = childViewModelData;
-                        Object.assign(typeNames, childNames);
-                        Object.assign(messages, childMessages);
-                        undefineds.splice(undefineds.length, 0, ...childUndefineds);
-                    }
-                } else {
-                    viewModelData[key] = value;
-                }
-            }
-
-            return {
-                viewModelData,
-                typeNames,
-                messages,
-                undefineds
-            };
-        },
-
-        getViewModelKeys(viewModel) {
-            if (canReflect.isListLike(viewModel)) {
-                return canReflect.getOwnEnumerableKeys( viewModel )
-            }
-
-            if (canReflect.isMapLike(viewModel)) {
-                return canReflect.getOwnKeys( viewModel )
-            }
-        },
-
-        getElementKeys(el) {
-            const keysSet = new Set([]);
-            const keysMap = el.attributes;
-
-            for (let i=0; i<keysMap.length; i++) {
-                let key = keysMap[i].name.split(/:to|:from|:bind/)[0];
-                key = key.split(":")[key.split(":").length - 1]
-                keysSet.add(key);
-            }
-
-            return Array.from(keysSet);
-        },
-
-        getUniqueTagName(el) {
-            let tagName = el.tagName.toLowerCase();
-            const els = document.querySelectorAll(tagName);
-            tagName = `<${tagName}>`;
-
-            if (els.length > 1) {
-                let index = 0;
-
-                Array.prototype.some.call(els, (currentEl, currentIndex) => {
-                    if(currentEl === el) {
-                        index = currentIndex;
-                        return true;
-                    }
-                });
-
-                tagName = `${tagName}[${index}]`;
-            }
-
-            return tagName;
-        },
-
-        getComponentTreeDataForNode({ el, selectedComponent, parentPath = "" }) {
-            let childList = [];
-
-            const treeWalker = document.createTreeWalker(
-                el,
-                NodeFilter.SHOW_ELEMENT,
-                {
-                    acceptNode(node) {
-                        return NodeFilter.FILTER_ACCEPT;
-                    }
-                },
-                false
-            );
-
-            let node = treeWalker.firstChild();
-            while(node) {
-                if (node[viewModelSymbol]) {
-                    let nodeData = {
-                        tagName: node.tagName.toLowerCase(),
-                        id: this.getNodeId(node),
-                        children: this.getComponentTreeDataForNode({ el: node, selectedComponent }),
-                        selected: node === selectedComponent
-                    };
-                    // cache element so it can be retrieved later when
-                    // a component is selected in component tree
-                    nodeToElementMap.set(nodeData, node);
-                    childList.push(nodeData);
-                } else {
-                    childList = childList.concat(
-                        this.getComponentTreeDataForNode({ el: node, selectedComponent })
-                    );
-                }
-                node = treeWalker.nextSibling();
-            }
-
-            return childList;
-        },
-
-        getNodeId(node) {
-            let id = nodeToIdMap.get(node);
-
-            if (!id) {
-                id = nextNodeId++;
-                nodeToIdMap.set(node, id);
-            }
-
-            return id;
-        },
-
-        getNodeById(id) {
-            for(let i=0; i<componentTree.length; i++) {
-                let node = this.checkNodeAndChildren(componentTree[i], id);
-                if (node) {
-                    return node;
-                }
-            }
-        },
-
-        checkNodeAndChildren(parent, id) {
-            if (parent.id === id) {
-                return parent;
-            }
-
-            for(let i=0; i<parent.children.length; i++) {
-                let found = this.checkNodeAndChildren(parent.children[i], id);
-                if (found) {
-                    return found;
-                }
-            }
-        },
-
-        get canObservation() {
-            return canObservation || window.can.Observation;
-        },
-
-        get canReflect() {
-            return canReflect;
-        },
-
-        get canQueues() {
-            return canQueues;
-        }
-    };
-}());
+	// CanJS modules set up by register function
+	let viewModelSymbol,
+		canObservation,
+		canQueues,
+		canReflect,
+		formatGraph,
+		getGraph;
+
+	// component tree variables
+	let nextNodeId = 0;
+	let componentTree = [];
+	const nodeToIdMap = new WeakMap();
+	const nodeToElementMap = new WeakMap();
+
+	// breakpoints variables
+	let nextBreakpointId = 0;
+	const breakpoints = [];
+	const breakpointToObservableMap = new WeakMap();
+	const noop = () => {};
+
+	// helper functions
+	const getObjAtKey = (obj, key) => {
+		if (!key) {
+			return obj;
+		}
+
+		const parts = key.split(".");
+
+		return parts.reduce((parent, key) => {
+			return canReflect.getKeyValue(parent, key);
+		}, obj);
+	};
+
+	const getLastParent = (obj, key) => {
+		return getObjAtKey(
+			obj,
+			key
+				.split(".")
+				.slice(0, -1)
+				.join(".")
+		);
+	};
+
+	const getLastKey = path => {
+		return path.split(".").pop();
+	};
+
+	const getIndexOfItemInArrayWithId = (arr, id) => {
+		let index = -1;
+
+		arr.some((item, i) => {
+			if (item.id === id) {
+				index = i;
+				return true;
+			}
+		});
+
+		return index;
+	};
+
+	const sendEventToBackgroundScript = detail => {
+		const registrationEvent = new CustomEvent("__CANJS_DEVTOOLS_EVENT__", {
+			detail
+		});
+		document.dispatchEvent(registrationEvent);
+	};
+
+	// add path information to component tree node and its children (recursively)
+	const addPaths = (node, index, parentPath) => {
+		let path = parentPath ? `${parentPath}.children.${index}` : `${index}`;
+		return Object.assign(node, {
+			path,
+			children: node.children.map((node, index) => addPaths(node, index, path))
+		});
+	};
+
+	// expose devtools namespace on the window
+	window.__CANJS_DEVTOOLS__ = {
+		// flag indicating whether register has been called
+		registered: false,
+
+		// element selected in CanJS Devtools Panel
+		$0: null,
+
+		// path of element selected
+		pathOf$0: null,
+
+		/*
+		 * methods called by devtools panels
+		 */
+		register(can) {
+			viewModelSymbol = can.Symbol.for("can.viewModel");
+			canObservation = can.Observation;
+			canQueues = can.queues;
+			canReflect = can.Reflect;
+			formatGraph = can.formatGraph;
+			getGraph = can.getGraph;
+
+			// register page so inspectedWindow.eval can call devtools functions in this frame
+			sendEventToBackgroundScript({ type: "page-loaded" });
+
+			this.registered = true;
+		},
+
+		getViewModelData(el, options) {
+			// if $0 is not in this frame, el will be null
+			if (!el) {
+				return this.makeIgnoreResponse("$0 is not in this frame");
+			}
+
+			// handle the user having devtools open and navigating to a page without can
+			if (!this.registered) {
+				return this.makeErrorResponse(this.NO_CAN_MSG);
+			}
+
+			const elementWithViewModel = this.getNearestElementWithViewModel(el);
+
+			if (!elementWithViewModel) {
+				return this.makeIgnoreResponse(
+					"&lt;" + el.tagName.toLowerCase() + "&gt; does not have a viewModel"
+				);
+			}
+
+			const viewModel = elementWithViewModel[viewModelSymbol];
+			const {
+				viewModelData,
+				typeNames,
+				messages,
+				undefineds
+			} = this.getSerializedViewModelData(viewModel, options);
+
+			return this.makeSuccessResponse({
+				tagName: this.getUniqueTagName(elementWithViewModel),
+				viewModelData,
+				typeNames,
+				messages,
+				undefineds
+			});
+		},
+
+		updateViewModel(el, patches) {
+			// if $0 is not in this frame, el will be null
+			if (!el) {
+				return this.makeIgnoreResponse("$0 is not in this frame");
+			}
+
+			// handle the user having devtools open and navigating to a page without can
+			if (!this.registered) {
+				return this.makeErrorResponse(this.NO_CAN_MSG);
+			}
+
+			const elementWithViewModel = this.getNearestElementWithViewModel(el);
+
+			if (elementWithViewModel) {
+				const viewModel = elementWithViewModel[viewModelSymbol];
+				let parentObj, lastKey;
+
+				patches.forEach(({ type, key, value, index, deleteCount, insert }) => {
+					switch (type) {
+						case "add":
+						case "set":
+							parentObj = getLastParent(viewModel, key);
+							lastKey = getLastKey(key);
+							canReflect.setKeyValue(parentObj, lastKey, value);
+							break;
+						case "delete":
+							parentObj = getLastParent(viewModel, key);
+							lastKey = getLastKey(key);
+							canReflect.deleteKeyValue(parentObj, lastKey);
+							break;
+						case "splice":
+							parentObj = getObjAtKey(viewModel, key);
+							parentObj.splice(index, deleteCount, ...insert);
+							break;
+					}
+				});
+			}
+		},
+
+		getBindingsGraphData(el, key) {
+			// if $0 is not in this frame, el will be null
+			if (!el) {
+				return this.makeIgnoreResponse("$0 is not in this frame");
+			}
+
+			// handle the user having devtools open and navigating to a page without can
+			if (!this.registered) {
+				return this.makeErrorResponse(this.NO_CAN_MSG);
+			}
+
+			const hasViewModel = el[viewModelSymbol];
+			const obj = hasViewModel ? hasViewModel : el;
+
+			const graphData = formatGraph(getGraph(obj, key));
+
+			return this.makeSuccessResponse({
+				availableKeys: hasViewModel
+					? this.getViewModelKeys(obj)
+					: this.getElementKeys(el),
+				selectedObj:
+					"<" +
+					el.tagName.toLowerCase() +
+					">" +
+					(hasViewModel ? ".viewModel" : ""),
+				graphData: graphData
+			});
+		},
+
+		queuesStack() {
+			if (!this.registered) {
+				// don't show an error for this because unlike ViewModel and Graph functions,
+				// this can't check if it is the correct frame by using $0.
+				// So just assume it's not the correct frame if register hasn't been called.
+				return this.makeIgnoreResponse(this.NO_CAN_MSG);
+			}
+
+			const stack = canQueues.stack();
+
+			return this.makeSuccessResponse({
+				frameURL: window.location.href,
+
+				stack: stack.map(task => {
+					return {
+						queue: task.meta && task.meta.stack.name,
+						context: canReflect.getName(task.context),
+						functionName: canReflect.getName(task.fn),
+						metaLog: task.meta && task.meta.log && task.meta.log.join(" "),
+						metaReasonLog:
+							task.meta && task.meta.reasonLog && task.meta.reasonLog.join(" ")
+					};
+				})
+			});
+		},
+
+		inspectTask(index) {
+			if (!this.registered) {
+				return this.makeErrorResponse(this.NO_CAN_MSG);
+			}
+
+			const stack = canQueues.stack();
+
+			if (stack && stack[index] && stack[index].fn) {
+				inspect(stack[index].fn);
+			}
+		},
+
+		getComponentTreeData() {
+			if (!this.registered) {
+				// don't show an error for this because unlike ViewModel and Graph functions,
+				// this can't check if it is the correct frame by using $0.
+				// So just assume it's not the correct frame if register hasn't been called.
+				return this.makeIgnoreResponse(this.NO_CAN_MSG);
+			}
+
+			// cache componetTree so it can be used to find nodes by Id
+			componentTree = this.getComponentTreeDataForNode({
+				el: document.body,
+				selectedComponent: this.getNearestElementWithViewModel(window.$0)
+			}).map((node, index) => addPaths(node, index));
+
+			return this.makeSuccessResponse({
+				tree: componentTree
+			});
+		},
+
+		getComponentById(id) {
+			const node = this.getNodeById(id);
+			return nodeToElementMap.get(node);
+		},
+
+		selectComponentById(id) {
+			const node = this.getNodeById(id);
+			this.$0 = nodeToElementMap.get(node);
+			this.pathOf$0 = node.path;
+		},
+
+		getBreakpoints() {
+			return this.makeSuccessResponse({
+				breakpoints
+			});
+		},
+
+		addBreakpoint({
+			expression,
+			observation,
+			observationExpression,
+			error,
+			enabled = true,
+			path
+		}) {
+			if (error) {
+				return this.makeErrorResponse(error);
+			}
+
+			// serializable data only
+			const breakpoint = {
+				id: nextBreakpointId++,
+				expression,
+				observationExpression,
+				enabled,
+				path
+			};
+
+			breakpoints.push(breakpoint);
+
+			// send updated list of breakpoints to background script
+			sendEventToBackgroundScript({
+				type: "set-breakpoints",
+				data: breakpoints
+			});
+
+			if (observation) {
+				Object.defineProperty(observation.dependencyChange, "name", {
+					value: `${expression} debugger`
+				});
+
+				if (enabled) {
+					canReflect.onValue(observation, noop);
+				}
+
+				breakpointToObservableMap.set(breakpoint, observation);
+			}
+
+			return this.getBreakpoints();
+		},
+
+		toggleBreakpoint(id) {
+			const index = getIndexOfItemInArrayWithId(breakpoints, id);
+			const breakpoint = breakpoints[index];
+			breakpoint.enabled = !breakpoint.enabled;
+
+			// send updated list of breakpoints to background script
+			sendEventToBackgroundScript({
+				type: "set-breakpoints",
+				data: breakpoints
+			});
+
+			const observation = breakpointToObservableMap.get(breakpoint);
+			if (observation) {
+				if (breakpoint.enabled) {
+					canReflect.onValue(observation, noop);
+				} else {
+					canReflect.offValue(observation, noop);
+				}
+			}
+
+			return this.getBreakpoints();
+		},
+
+		deleteBreakpoint(id) {
+			const index = getIndexOfItemInArrayWithId(breakpoints, id);
+			const breakpoint = breakpoints[index];
+			const observation = breakpointToObservableMap.get(breakpoint);
+			if (observation) {
+				canReflect.offValue(observation);
+			}
+			breakpoints.splice(index, 1);
+
+			// send updated list of breakpoints to background script
+			sendEventToBackgroundScript({
+				type: "set-breakpoints",
+				data: breakpoints
+			});
+
+			return this.getBreakpoints();
+		},
+
+		/*
+		 * methods used to build responses
+		 */
+		makeResponse(status, detail) {
+			return {
+				status: status,
+				detail: detail
+			};
+		},
+
+		makeIgnoreResponse(detail) {
+			return this.makeResponse("ignore", detail);
+		},
+
+		makeErrorResponse(detail) {
+			return this.makeResponse("error", detail);
+		},
+
+		makeSuccessResponse(detail) {
+			return this.makeResponse("success", detail);
+		},
+
+		NO_CAN_MSG:
+			'CanJS was not found on this page. If it is using CanJS, see the <a target="_blank" href="https://canjs.com/doc/guides/debugging.html#InstallingCanJSDevtools">installation instructions</a>.',
+
+		/*
+		 * helper methods
+		 */
+		getNearestElementWithViewModel(el) {
+			if (!el) {
+				return undefined;
+			}
+
+			const viewModel = el[viewModelSymbol];
+			return viewModel
+				? el
+				: el.parentNode
+				? this.getNearestElementWithViewModel(el.parentNode)
+				: undefined;
+		},
+
+		getSerializedViewModelData(
+			viewModel,
+			{ expandedKeys = [] } = {},
+			parentPath = ""
+		) {
+			const viewModelKeys = this.getViewModelKeys(viewModel);
+			const viewModelData = {};
+			const typeNames = {};
+			const messages = {};
+			const undefineds = [];
+
+			if (viewModelKeys.length === 0) {
+				const type = canReflect.isObservableLike(viewModel)
+					? canReflect.isMoreListLikeThanMapLike(viewModel)
+						? "List"
+						: "Map"
+					: Array.isArray(viewModel)
+					? "Array"
+					: "Object";
+
+				messages[parentPath] = { type: "info", message: `${type} is empty` };
+			}
+
+			for (let i = 0; i < viewModelKeys.length; i++) {
+				let key = viewModelKeys[i];
+				let path = `${parentPath ? parentPath + "." : ""}${key}`;
+				let value;
+				try {
+					value = canReflect.getKeyValue(viewModel, key);
+				} catch (e) {
+					// handle non-serializable values (such as recursive and circular structures)
+					value = {};
+
+					// add error message for key
+					messages[path] = {
+						type: "error",
+						message: 'Error getting value of "' + path + '": ' + e.message
+					};
+				}
+
+				// don't serialize functions
+				if (typeof value === "function") {
+					viewModelData[key] = {};
+					typeNames[path] = "function";
+					messages[path] = {
+						type: "info",
+						message: value.toString()
+					};
+					continue;
+				}
+
+				if (value === null) {
+					viewModelData[key] = null;
+					continue;
+				}
+
+				if (value === undefined) {
+					undefineds.push(path);
+				}
+
+				if (typeof value === "object") {
+					viewModelData[key] = {};
+					typeNames[path] = canReflect.getName(value);
+
+					if (value instanceof Element) {
+						messages[path] = {
+							type: "info",
+							message: "CanJS Devtools does not expand HTML Elements"
+						};
+						continue;
+					}
+
+					// get serialized data for children of expanded keys
+					if (expandedKeys.indexOf(path) !== -1) {
+						let {
+							viewModelData: childViewModelData,
+							typeNames: childNames,
+							messages: childMessages,
+							undefineds: childUndefineds
+						} = this.getSerializedViewModelData(value, { expandedKeys }, path);
+
+						viewModelData[key] = childViewModelData;
+						Object.assign(typeNames, childNames);
+						Object.assign(messages, childMessages);
+						undefineds.splice(undefineds.length, 0, ...childUndefineds);
+					}
+				} else {
+					viewModelData[key] = value;
+				}
+			}
+
+			return {
+				viewModelData,
+				typeNames,
+				messages,
+				undefineds
+			};
+		},
+
+		getViewModelKeys(viewModel) {
+			if (canReflect.isListLike(viewModel)) {
+				return canReflect.getOwnEnumerableKeys(viewModel);
+			}
+
+			if (canReflect.isMapLike(viewModel)) {
+				return canReflect.getOwnKeys(viewModel);
+			}
+		},
+
+		getElementKeys(el) {
+			const keysSet = new Set([]);
+			const keysMap = el.attributes;
+
+			for (let i = 0; i < keysMap.length; i++) {
+				let key = keysMap[i].name.split(/:to|:from|:bind/)[0];
+				key = key.split(":")[key.split(":").length - 1];
+				keysSet.add(key);
+			}
+
+			return Array.from(keysSet);
+		},
+
+		getUniqueTagName(el) {
+			let tagName = el.tagName.toLowerCase();
+			const els = document.querySelectorAll(tagName);
+			tagName = `<${tagName}>`;
+
+			if (els.length > 1) {
+				let index = 0;
+
+				Array.prototype.some.call(els, (currentEl, currentIndex) => {
+					if (currentEl === el) {
+						index = currentIndex;
+						return true;
+					}
+				});
+
+				tagName = `${tagName}[${index}]`;
+			}
+
+			return tagName;
+		},
+
+		getComponentTreeDataForNode({ el, selectedComponent }) {
+			let childList = [];
+
+			const treeWalker = document.createTreeWalker(
+				el,
+				NodeFilter.SHOW_ELEMENT,
+				{
+					acceptNode() {
+						return NodeFilter.FILTER_ACCEPT;
+					}
+				},
+				false
+			);
+
+			let node = treeWalker.firstChild();
+			while (node) {
+				if (node[viewModelSymbol]) {
+					let nodeData = {
+						tagName: node.tagName.toLowerCase(),
+						id: this.getNodeId(node),
+						children: this.getComponentTreeDataForNode({
+							el: node,
+							selectedComponent
+						}),
+						selected: node === selectedComponent
+					};
+					// cache element so it can be retrieved later when
+					// a component is selected in component tree
+					nodeToElementMap.set(nodeData, node);
+					childList.push(nodeData);
+				} else {
+					childList = childList.concat(
+						this.getComponentTreeDataForNode({ el: node, selectedComponent })
+					);
+				}
+				node = treeWalker.nextSibling();
+			}
+
+			return childList;
+		},
+
+		getNodeId(node) {
+			let id = nodeToIdMap.get(node);
+
+			if (!id) {
+				id = nextNodeId++;
+				nodeToIdMap.set(node, id);
+			}
+
+			return id;
+		},
+
+		getNodeById(id) {
+			for (let i = 0; i < componentTree.length; i++) {
+				let node = this.checkNodeAndChildren(componentTree[i], id);
+				if (node) {
+					return node;
+				}
+			}
+		},
+
+		checkNodeAndChildren(parent, id) {
+			if (parent.id === id) {
+				return parent;
+			}
+
+			for (let i = 0; i < parent.children.length; i++) {
+				let found = this.checkNodeAndChildren(parent.children[i], id);
+				if (found) {
+					return found;
+				}
+			}
+		},
+
+		get canObservation() {
+			return canObservation || window.can.Observation;
+		},
+
+		get canReflect() {
+			return canReflect;
+		},
+
+		get canQueues() {
+			return canQueues;
+		}
+	};
+})();

--- a/index.mjs
+++ b/index.mjs
@@ -1,53 +1,53 @@
 import helpers from "./canjs-devtools-helpers.mjs";
 
 function initializePanel() {
-    chrome.devtools.panels.create(
-        "CanJS",
-        "images/canjs-16-enabled.png",
-        "panel/index.html"
-    );
+	chrome.devtools.panels.create(
+		"CanJS",
+		"images/canjs-16-enabled.png",
+		"panel/index.html"
+	);
 }
 
 function initializeSidebar(name, location, page, height) {
-    chrome.devtools.panels[location].createSidebarPane(name, function(sidebar) {
-        sidebar.setPage(page);
+	chrome.devtools.panels[location].createSidebarPane(name, function(sidebar) {
+		sidebar.setPage(page);
 
-        if(height) {
-            sidebar.setHeight(height);
-        }
-    });
+		if (height) {
+			sidebar.setHeight(height);
+		}
+	});
 }
 
 (function initializeDevtools() {
-    var registeredFrames = helpers.registeredFrames;
-    var frameURLs = Object.keys(registeredFrames);
+	var registeredFrames = helpers.registeredFrames;
+	var frameURLs = Object.keys(registeredFrames);
 
-    if (frameURLs.length) {
-        // initialize the CanJS panel
-        initializePanel();
+	if (frameURLs.length) {
+		// initialize the CanJS panel
+		initializePanel();
 
-        // initialize all the sidebars
-        initializeSidebar(
-            "CanJS ViewModel",
-            "elements",
-            "viewmodel-editor/index.html"
-        );
+		// initialize all the sidebars
+		initializeSidebar(
+			"CanJS ViewModel",
+			"elements",
+			"viewmodel-editor/index.html"
+		);
 
-        initializeSidebar(
-            "CanJS Bindings Graph",
-            "elements",
-            "bindings-graph/index.html"
-        );
+		initializeSidebar(
+			"CanJS Bindings Graph",
+			"elements",
+			"bindings-graph/index.html"
+		);
 
-        initializeSidebar(
-            "CanJS Queues Stack",
-            "sources",
-            "queues-stack/index.html",
-            "400px"
-        );
-    } else {
-        // popup and icon are default to the `no-can` version,
-        // so don't need to be set here
-        setTimeout(initializeDevtools, 1000);
-    }
-}());
+		initializeSidebar(
+			"CanJS Queues Stack",
+			"sources",
+			"queues-stack/index.html",
+			"400px"
+		);
+	} else {
+		// popup and icon are default to the `no-can` version,
+		// so don't need to be set here
+		setTimeout(initializeDevtools, 1000);
+	}
+})();

--- a/manifest.json
+++ b/manifest.json
@@ -1,32 +1,32 @@
 {
-    "name": "CanJS DevTools",
-    "description": "DevTools Extension for CanJS",
-    "version": "0.0.39",
-    "icons": {
-        "16": "images/canjs-16-enabled.png",
-        "48": "images/canjs-48-enabled.png",
-        "128": "images/canjs-128-enabled.png"
-    },
-    "manifest_version": 2,
-    "devtools_page": "index.html",
-    "background": {
-        "scripts": [ "canjs-devtools-background.js" ]
-    },
-    "content_scripts": [ {
-        "all_frames": true,
-        "js": [ "canjs-devtools-content-script.js" ],
-        "matches": [ "*://*/*" ]
-    } ],
-    "web_accessible_resources": [
-        "canjs-devtools-injected-script.js"
-    ],
-    "permissions": [],
-    "content_security_policy": "script-src 'self' 'unsafe-eval'; object-src 'self'",
-    "browser_action": {
-        "default_title": "CanJS Devtools",
-        "default_popup": "popups/no-can.html",
-        "default_icon": {
-            "16": "images/canjs-16-disabled.png"
-        }
+  "name": "CanJS DevTools",
+  "description": "DevTools Extension for CanJS",
+  "version": "0.0.39",
+  "icons": {
+    "16": "images/canjs-16-enabled.png",
+    "48": "images/canjs-48-enabled.png",
+    "128": "images/canjs-128-enabled.png"
+  },
+  "manifest_version": 2,
+  "devtools_page": "index.html",
+  "background": {
+    "scripts": ["canjs-devtools-background.js"]
+  },
+  "content_scripts": [
+    {
+      "all_frames": true,
+      "js": ["canjs-devtools-content-script.js"],
+      "matches": ["*://*/*"]
     }
+  ],
+  "web_accessible_resources": ["canjs-devtools-injected-script.js"],
+  "permissions": [],
+  "content_security_policy": "script-src 'self' 'unsafe-eval'; object-src 'self'",
+  "browser_action": {
+    "default_title": "CanJS Devtools",
+    "default_popup": "popups/no-can.html",
+    "default_icon": {
+      "16": "images/canjs-16-disabled.png"
+    }
+  }
 }

--- a/package.json
+++ b/package.json
@@ -13,9 +13,13 @@
     "web": "http://bitovi.com/"
   },
   "scripts": {
+    "lint": "eslint . ",
     "testee": "testee test/test.html --browsers firefox",
     "testee-mjs": "testee test/mjs-test.html --browsers firefox",
-    "test": "npm run testee && npm run testee-mjs"
+    "test": "npm run lint && npm run testee && npm run testee-mjs"
+  },
+  "steal": {
+    "forceES5": false
   },
   "license": "MIT",
   "bugs": {
@@ -23,11 +27,12 @@
   },
   "homepage": "https://canjs.com",
   "dependencies": {
-    "can-devtools-components": "^0.11.8"
+    "can-devtools-components": "^0.11.10-0"
   },
   "devDependencies": {
-    "can": "^5.17.2",
+    "can": "^6.2.3",
     "chai": "^4.2.0",
+    "eslint": "^6.5.1",
     "steal": "^2.1.10",
     "steal-mocha": "^2.0.1",
     "testee": "^0.9.1"

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
   },
   "devDependencies": {
     "can": "^6.2.3",
+    "can-define": "^2.8.0",
     "chai": "^4.2.0",
     "eslint": "^6.5.1",
     "steal": "^2.1.10",

--- a/panel/index.html
+++ b/panel/index.html
@@ -1,19 +1,30 @@
-<!doctype html>
-<html>
-    <head>
-        <link rel="stylesheet" type="text/css" href="../node_modules/can-devtools-components/dist/can-devtools-components.css">
-        <style>
-            html, body {
-                height: 100%;
-            }
-            canjs-devtools-panel {
-                display: block;
-                height: 100%;
-            }
-        </style>
-    </head>
-    <body>
-        <canjs-devtools-panel></canjs-devtools-panel>
-        <script type="module" src="panel.mjs"></script>
-    </body>
+<!DOCTYPE html>
+<html lang="en">
+	<head>
+		<meta charset="UTF-8" />
+		<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+		<meta http-equiv="X-UA-Compatible" content="ie=edge" />
+		<title>canjs-devtools-panel</title>
+		<link
+			rel="stylesheet"
+			type="text/css"
+			href="../node_modules/can-devtools-components/dist/can-devtools-components.css"
+		/>
+		<style>
+			html,
+			body {
+				height: 100%;
+			}
+			canjs-devtools-panel {
+				display: block;
+				height: 100%;
+			}
+		</style>
+	</head>
+	<body>
+		<body>
+			<canjs-devtools-panel></canjs-devtools-panel>
+			<script type="module" src="panel.mjs"></script>
+		</body>
+	</body>
 </html>

--- a/panel/panel-test.js
+++ b/panel/panel-test.js
@@ -1,99 +1,149 @@
-import mocha from "steal-mocha";
-import chai from "chai/chai";
-
-import helpers from "../canjs-devtools-helpers.mjs";
+import { assert } from "chai/chai";
+import "steal-mocha";
 
 import Panel from "./panel.mjs";
-const PanelVM = Panel.ViewModel;
-
-const assert = chai.assert;
+import helpers from "../canjs-devtools-helpers.mjs";
 
 describe("canjs-devtools-panel", () => {
-    let origRunDevtoolsFunction = helpers.runDevtoolsFunction;
+	let origRunDevtoolsFunction = helpers.runDevtoolsFunction;
 
-    beforeEach(() => {
-        helpers.runDevtoolsFunction = () => {};
-    });
+	beforeEach(() => {
+		helpers.runDevtoolsFunction = () => {};
+	});
 
-    afterEach(() => {
-        helpers.runDevtoolsFunction = origRunDevtoolsFunction;
-    });
+	afterEach(() => {
+		helpers.runDevtoolsFunction = origRunDevtoolsFunction;
+	});
 
-    it("error", () => {
-        const vm = new PanelVM();
-        vm.listenTo("error", () => {});
+	it("panelError", () => {
+		const vm = new Panel();
+		vm.initialize();
+		vm.listenTo("panelError", () => {});
 
-        assert.equal(vm.error, undefined, "no error by default");
+		assert.equal(vm.panelError, undefined, "no error by default");
 
-        vm.error = "there was an error";
-        assert.equal(vm.error, "there was an error", "error can be set");
+		vm.panelError = "there was an error";
+		assert.equal(vm.panelError, "there was an error", "error can be set");
 
-        vm.selectedNode = {};
-        assert.equal(vm.error, undefined, "error is reset when a node is selected");
-    });
+		vm.selectedNode = {};
+		assert.equal(
+			vm.panelError,
+			undefined,
+			"error is reset when a node is selected"
+		);
+	});
 
-    it("breakpointsError", () => {
-        const vm = new PanelVM();
-        vm.listenTo("breakpointsError", () => {});
+	it("breakpointsError", () => {
+		const vm = new Panel();
+		vm.initialize();
+		vm.listenTo("breakpointsError", () => {});
 
-        assert.equal(vm.breakpointsError, undefined, "no breakpointsError by default");
+		assert.equal(
+			vm.breakpointsError,
+			undefined,
+			"no breakpointsError by default"
+		);
 
-        vm.breakpointsError = "there was an error";
-        assert.equal(vm.breakpointsError, "there was an error", "breakpointsError can be set");
+		vm.breakpointsError = "there was an error";
+		assert.equal(
+			vm.breakpointsError,
+			"there was an error",
+			"breakpointsError can be set"
+		);
 
-        vm.selectedNode = {};
-        assert.equal(vm.breakpointsError, undefined, "breakpointsError is reset when a node is selected");
-    });
+		vm.selectedNode = {};
+		assert.equal(
+			vm.breakpointsError,
+			undefined,
+			"breakpointsError is reset when a node is selected"
+		);
+	});
 
-    it("viewModelData", () => {
-        const vm = new PanelVM();
-        vm.listenTo("viewModelData", () => {});
+	it("viewModelData", () => {
+		const vm = new Panel();
+		vm.initialize();
+		vm.listenTo("viewModelData", () => {});
 
-        assert.equal(vm.viewModelData, undefined, "no viewModelData by default");
+		assert.equal(vm.viewModelData, undefined, "no viewModelData by default");
 
-        vm.viewModelData = { foo: "bar" };
-        assert.deepEqual(vm.viewModelData.serialize(), { foo: "bar" }, "viewModelData can be set");
+		vm.viewModelData = { foo: "bar" };
+		assert.deepEqual(
+			vm.viewModelData.serialize(),
+			{ foo: "bar" },
+			"viewModelData can be set"
+		);
 
-        vm.selectedNode = {};
-        assert.deepEqual(vm.viewModelData.serialize(), {}, "viewModelData is reset when a node is selected");
-    });
+		vm.selectedNode = {};
+		assert.deepEqual(
+			vm.viewModelData.serialize(),
+			{},
+			"viewModelData is reset when a node is selected"
+		);
+	});
 
-    it("typeNamesData", () => {
-        const vm = new PanelVM();
-        vm.listenTo("typeNamesData", () => {});
+	it("typeNamesData", () => {
+		const vm = new Panel();
+		vm.initialize();
+		vm.listenTo("typeNamesData", () => {});
 
-        assert.equal(vm.typeNamesData, undefined, "no typeNamesData by default");
+		assert.equal(vm.typeNamesData, undefined, "no typeNamesData by default");
 
-        vm.typeNamesData = { foo: "bar" };
-        assert.deepEqual(vm.typeNamesData.serialize(), { foo: "bar" }, "typeNamesData can be set");
+		vm.typeNamesData = { foo: "bar" };
+		assert.deepEqual(
+			vm.typeNamesData.serialize(),
+			{ foo: "bar" },
+			"typeNamesData can be set"
+		);
 
-        vm.selectedNode = {};
-        assert.deepEqual(vm.typeNamesData.serialize(), {}, "typeNamesData is reset when a node is selected");
-    });
+		vm.selectedNode = {};
+		assert.deepEqual(
+			vm.typeNamesData.serialize(),
+			{},
+			"typeNamesData is reset when a node is selected"
+		);
+	});
 
-    it("messages", () => {
-        const vm = new PanelVM();
-        vm.listenTo("messages", () => {});
+	it("messages", () => {
+		const vm = new Panel();
+		vm.initialize();
+		vm.listenTo("messages", () => {});
 
-        assert.equal(vm.messages, undefined, "no messages by default");
+		assert.equal(vm.messages, undefined, "no messages by default");
 
-        vm.messages = { foo: "bar" };
-        assert.deepEqual(vm.messages.serialize(), { foo: "bar" }, "messages can be set");
+		vm.messages = { foo: "bar" };
+		assert.deepEqual(
+			vm.messages.serialize(),
+			{ foo: "bar" },
+			"messages can be set"
+		);
 
-        vm.selectedNode = {};
-        assert.deepEqual(vm.messages.serialize(), {}, "messages is reset when a node is selected");
-    });
+		vm.selectedNode = {};
+		assert.deepEqual(
+			vm.messages.serialize(),
+			{},
+			"messages is reset when a node is selected"
+		);
+	});
 
-    it("undefineds", () => {
-        const vm = new PanelVM();
-        vm.listenTo("undefineds", () => {});
+	it("undefineds", () => {
+		const vm = new Panel();
+		vm.initialize();
+		vm.listenTo("undefineds", () => {});
 
-        assert.equal(vm.undefineds, undefined, "no undefineds by default");
+		assert.equal(vm.undefineds, undefined, "no undefineds by default");
 
-        vm.undefineds = [ "foo", "bar" ];
-        assert.deepEqual(vm.undefineds.serialize(), [ "foo", "bar" ], "undefineds can be set");
+		vm.undefineds = ["foo", "bar"];
+		assert.deepEqual(
+			vm.undefineds.serialize(),
+			["foo", "bar"],
+			"undefineds can be set"
+		);
 
-        vm.selectedNode = {};
-        assert.deepEqual(vm.undefineds.serialize(), [], "undefineds is reset when a node is selected");
-    });
+		vm.selectedNode = {};
+		assert.deepEqual(
+			vm.undefineds.serialize(),
+			[],
+			"undefineds is reset when a node is selected"
+		);
+	});
 });

--- a/panel/test.html
+++ b/panel/test.html
@@ -1,4 +1,16 @@
-<!doctype html>
-<script src="../node_modules/steal/steal.js"
-    mocha="bdd"
-    main="panel/panel-test"></script>
+<!DOCTYPE html>
+<html lang="en">
+	<head>
+		<meta charset="UTF-8" />
+		<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+		<meta http-equiv="X-UA-Compatible" content="ie=edge" />
+		<title>canjs-devtools-panel</title>
+	</head>
+	<body>
+		<script
+			src="../node_modules/steal/steal.js"
+			mocha="bdd"
+			main="panel/panel-test"
+		></script>
+	</body>
+</html>

--- a/popups/can.html
+++ b/popups/can.html
@@ -1,21 +1,26 @@
-<!doctype html>
+<!DOCTYPE html>
 <html>
-    <head>
-        <style>
-            html {
-                min-width: 400px;
-            }
-        </style>
-    </head>
-    <body>
-        <h1>This page is using CanJS</h1>
-        <p>CanJS devtools are integrated with the normal Chrome Developer tools</p>
-        <p>Open Developer Tools to find</p>
-        <ul>
-            <li>The ViewModel Editor in the sidebar of the Elements panel</li>
-            <li>The Bindings Graph in the sidebar of the Elements panel</li>
-            <li>The Queues Stack in the sidebar of the Sources panel</li>
-        </ul>
-        <p>For more info, see the <a target="_blank" href="https://canjs.com/doc/guides/debugging.html">Debugging Guide</a>.</p>
-    </body>
+	<head>
+		<style>
+			html {
+				min-width: 400px;
+			}
+		</style>
+	</head>
+	<body>
+		<h1>This page is using CanJS</h1>
+		<p>CanJS devtools are integrated with the normal Chrome Developer tools</p>
+		<p>Open Developer Tools to find</p>
+		<ul>
+			<li>The ViewModel Editor in the sidebar of the Elements panel</li>
+			<li>The Bindings Graph in the sidebar of the Elements panel</li>
+			<li>The Queues Stack in the sidebar of the Sources panel</li>
+		</ul>
+		<p>
+			For more info, see the
+			<a target="_blank" href="https://canjs.com/doc/guides/debugging.html"
+				>Debugging Guide</a
+			>.
+		</p>
+	</body>
 </html>

--- a/popups/no-can.html
+++ b/popups/no-can.html
@@ -1,14 +1,21 @@
-<!doctype html>
+<!DOCTYPE html>
 <html>
-    <head>
-        <style>
-            html {
-                min-width: 400px;
-            }
-        </style>
-    </head>
-    <body>
-        <h1>CanJS was not found on this page</h1>
-        <p>If it is using CanJS, see the <a target="_blank" href="https://canjs.com/doc/guides/debugging.html#InstallingCanJSDevtools">installation instructions</a>.</p>
-    </body>
+	<head>
+		<style>
+			html {
+				min-width: 400px;
+			}
+		</style>
+	</head>
+	<body>
+		<h1>CanJS was not found on this page</h1>
+		<p>
+			If it is using CanJS, see the
+			<a
+				target="_blank"
+				href="https://canjs.com/doc/guides/debugging.html#InstallingCanJSDevtools"
+				>installation instructions</a
+			>.
+		</p>
+	</body>
 </html>

--- a/queues-stack/index.html
+++ b/queues-stack/index.html
@@ -1,17 +1,21 @@
-<!doctype html>
+<!DOCTYPE html>
 <html>
-    <head>
-        <link rel="stylesheet" type="text/css" href="../node_modules/can-devtools-components/dist/can-devtools-components.css">
-        <style>
-            body {
-                margin: 0;
-                padding: 0;
-                overflow: hidden;
-            }
-        </style>
-    </head>
-    <body>
-        <canjs-devtools-queues-stack></canjs-devtools-queues-stack>
-        <script type="module" src="queues-stack.mjs"></script>
-    </body>
+	<head>
+		<link
+			rel="stylesheet"
+			type="text/css"
+			href="../node_modules/can-devtools-components/dist/can-devtools-components.css"
+		/>
+		<style>
+			body {
+				margin: 0;
+				padding: 0;
+				overflow: hidden;
+			}
+		</style>
+	</head>
+	<body>
+		<canjs-devtools-queues-stack></canjs-devtools-queues-stack>
+		<script type="module" src="queues-stack.mjs"></script>
+	</body>
 </html>

--- a/queues-stack/queues-stack.mjs
+++ b/queues-stack/queues-stack.mjs
@@ -1,76 +1,87 @@
-import { Component, DefineList } from "../node_modules/can-devtools-components/dist/queues-logstack.mjs";
+import {
+	ObservableArray,
+	StacheElement,
+	type
+} from "../node_modules/can-devtools-components/dist/queues-logstack.mjs";
 
 import helpers from "../canjs-devtools-helpers.mjs";
 
-Component.extend({
-    tag: "canjs-devtools-queues-stack",
+class CanjsDevtoolsQueuesStack extends StacheElement {
+	static get view() {
+		return `
+			{{# if(this.stackError) }}
+				<h2>{{{ this.stackError }}}</h2>
+			{{ else }}
+				<queues-logstack
+					stack:from="this.stack"
+					inspectTask:from="this.inspectTask"
+				></queues-logstack>
+			{{/ if }}
+		`;
+	}
 
-    view: `
-        {{#if error}}
-            <h2>{{{error}}}</h2>
-        {{else}}
-            <queues-logstack
-                stack:from="stack"
-                inspectTask:from="inspectTask"
-            ></queues-logstack>
-        {{/if}}
-    `,
+	static get props() {
+		return {
+			stack: {
+				type: type.convert(ObservableArray),
 
-    ViewModel: {
-        stack: { Type: DefineList, Default: DefineList },
-        error: "string",
-        activeFrame: "string",
+				get default() {
+					return new ObservableArray();
+				}
+			},
 
-        inspectTask(taskIndex) {
-            helpers.runDevtoolsFunction({
-                fnString: "inspectTask(" + taskIndex + ")"
-            });
-        },
+			stackError: String,
+			activeFrame: String
+		};
+	}
 
-        connectedCallback() {
-            var vm = this;
+	connected() {
+		var vm = this;
 
-            var stopRefreshing = helpers.runDevtoolsFunction({
-                fnString: "queuesStack()",
-                refreshInterval: 100,
-                success: function(result) {
-                    var status = result.status;
-                    var stack = result.detail.stack;
-                    var frameURL = result.detail.frameURL;
+		var stopRefreshing = helpers.runDevtoolsFunction({
+			fnString: "queuesStack()",
+			refreshInterval: 100,
+			success: function(result) {
+				var status = result.status;
+				var stack = result.detail.stack;
+				var frameURL = result.detail.frameURL;
 
-                    switch(status) {
-                        case "ignore":
-                            break;
-                        case "error":
-                            vm.error = detail;
-                            break;
-                        case "success":
-                            // if response is received from a frame other than the
-                            // last `activeFrame`, only overwrite data if there is
-                            // data on the stack
-                            var shouldUpdate =
-                                (
-                                    frameURL === vm.activeFrame && // apply updates from the `activeFrame`
-                                        stack.length !== vm.stack.length // if the length is the same, we assume the list is the same so that sidebar doesn't flash
-                                ) ||
-                                (
-                                    frameURL !== vm.activeFrame && // apply updates from another frame only
-                                        stack.length !== 0 // if there are items on the stack
-                                );
+				switch (status) {
+					case "ignore":
+						break;
+					case "error":
+						vm.error = result.detail;
+						break;
+					case "success":
+						// if response is received from a frame other than the
+						// last `activeFrame`, only overwrite data if there is
+						// data on the stack
+						var shouldUpdate =
+							(frameURL === vm.activeFrame && // apply updates from the `activeFrame`
+								stack.length !== vm.stack.length) || // if the length is the same, we assume the list is the same so that sidebar doesn't flash
+							(frameURL !== vm.activeFrame && // apply updates from another frame only
+								stack.length !== 0); // if there are items on the stack
 
-                            if (shouldUpdate) {
-                                vm.activeFrame = frameURL;
-                                vm.stack = stack;
-                            }
+						if (shouldUpdate) {
+							vm.activeFrame = frameURL;
+							vm.stack = stack;
+						}
 
-                            break;
-                    }
-                }
-            });
+						break;
+				}
+			}
+		});
 
-            return function disconnect() {
-                stopRefreshing();
-            };
-        }
-    }
-});
+		return function disconnect() {
+			stopRefreshing();
+		};
+	}
+
+	inspectTask(taskIndex) {
+		helpers.runDevtoolsFunction({
+			fnString: "inspectTask(" + taskIndex + ")"
+		});
+	}
+}
+
+customElements.define("canjs-devtools-queues-stack", CanjsDevtoolsQueuesStack);

--- a/test/helpers-test.html
+++ b/test/helpers-test.html
@@ -1,4 +1,16 @@
-<!doctype html>
-<script src="../node_modules/steal/steal.js"
-    mocha="bdd"
-    main="test/helpers-test"></script>
+<!DOCTYPE html>
+<html lang="en">
+	<head>
+		<meta charset="UTF-8" />
+		<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+		<meta http-equiv="X-UA-Compatible" content="ie=edge" />
+		<title>helpers-test</title>
+	</head>
+	<body>
+		<script
+			src="../node_modules/steal/steal.js"
+			mocha="bdd"
+			main="test/helpers-test"
+		></script>
+	</body>
+</html>

--- a/test/helpers-test.js
+++ b/test/helpers-test.js
@@ -1,342 +1,444 @@
-import mocha from "steal-mocha";
-import chai from "chai/chai";
+import { assert } from "chai/chai";
+import steal from "@steal";
+import "steal-mocha";
 
-import { Component, DefineMap, DefineList, debug, Reflect, Observation, queues } from "can";
-
-const assert = chai.assert;
+import {
+	ObservableObject,
+	ObservableArray,
+	Reflect,
+	type,
+	Observation,
+	queues
+} from "can";
 
 describe("canjs-devtools-helpers", () => {
-    let helpers, windowChrome, chrome;
-
-    beforeEach((done) => {
-        // store original chrome api (it probably doesn't exist)
-        windowChrome = window.chrome;
-
-        chrome = {
-            devtools: {},
-            runtime: { onMessage: { addListener() {} } }
-        };
-        window.chrome = chrome;
-
-        steal.import("canjs-devtools-helpers.mjs")
-            .then((mod) => {
-                helpers = mod.default;
-                done();
-            });
-    });
-
-    afterEach(() => {
-        window.chrome = windowChrome;
-    });
-
-    describe("runDevtoolsFunction", () => {
-        let evalCalls;
-
-        beforeEach(() => {
-            evalCalls = [];
-
-            chrome.devtools = {
-                inspectedWindow: {
-                    eval(fnString, options, callback) {
-                        evalCalls.push({
-                            fnString: fnString.split("__CANJS_DEVTOOLS__.")[1],
-                            url: options.frameURL
-                        });
-
-                        // call success/error callback to make sure refresh happens
-                        callback();
-                    }
-                }
-            };
-        });
-
-        it("makes an eval call to each registered frame", () => {
-            helpers.registeredFrames = { "www.one.com": true, "www.two.com": true };
-
-            const teardown = helpers.runDevtoolsFunction({
-                fnString: "fooBar()"
-            });
-
-            assert.equal(evalCalls.length, 2);
-
-            assert.equal(evalCalls[0].fnString, "fooBar()");
-            assert.equal(evalCalls[0].url, "www.one.com");
-
-            assert.equal(evalCalls[1].fnString, "fooBar()");
-            assert.equal(evalCalls[1].url, "www.two.com");
-
-            // clean up frameChangeHandlers so this doesn't break other tests
-            teardown();
-        });
-
-        it("refreshes data every refreshInterval for frames that are still active", (done) => {
-            const refreshInterval = 5;
-            const refreshAllInterval = 10;
-
-            helpers.registeredFrames = {};
-
-            const teardown = helpers.runDevtoolsFunction({
-                fnString: "fooBar()",
-                refreshInterval,
-                refreshAllInterval
-            });
-
-            assert.equal(evalCalls.length, 0, "should not call eval if there are no frames");
-
-            helpers.registeredFrames = { "www.one.com": true, "www.two.com": true };
-
-            assert.equal(evalCalls.length, 2, "when frames change, should call eval for each frame");
-
-            assert.equal(evalCalls[0].fnString, "fooBar()");
-            assert.equal(evalCalls[0].url, "www.one.com");
-
-            assert.equal(evalCalls[1].fnString, "fooBar()");
-            assert.equal(evalCalls[1].url, "www.two.com");
-
-            setTimeout(() => {
-                assert.equal(evalCalls.length, 4, "should refresh data every refresh interval");
-
-                assert.equal(evalCalls[2].fnString, "fooBar()");
-                assert.equal(evalCalls[2].url, "www.one.com");
-
-                assert.equal(evalCalls[3].fnString, "fooBar()");
-                assert.equal(evalCalls[3].url, "www.two.com");
-
-                // remove second frame
-                helpers.registeredFrames = { "www.one.com": true };
-
-                assert.equal(evalCalls.length, 5, "should not refresh data for removed frame");
-
-                assert.equal(evalCalls[4].fnString, "fooBar()");
-                assert.equal(evalCalls[4].url, "www.one.com");
-
-                // replace frame with a new one
-                helpers.registeredFrames = { "www.three.com": true };
-
-                assert.equal(evalCalls.length, 6, "should load data for new frame");
-
-                assert.equal(evalCalls[5].fnString, "fooBar()");
-                assert.equal(evalCalls[5].url, "www.three.com");
-
-                // stop refreshing so this doesn't break other tests
-                teardown();
-                done();
-            }, refreshInterval);
-        });
-    });
-
-    describe("getBreakpointEvalString", () => {
-        let $0, devtools, debuggerHitCount, mock;
-
-        beforeEach(() => {
-            $0 = { [Symbol.for('can.viewModel')]: {} };
-
-            devtools = {
-                $0,
-                canReflect: Reflect,
-                canObservation: Observation,
-                canQueues: queues,
-                register() {}
-            };
-
-            window.__CANJS_DEVTOOLS__ = devtools;
-
-            // mock debugger so we can track when it is read
-            debuggerHitCount = 0;
-            mock = {
-                get _debugger() {
-                    debuggerHitCount++;
-                }
-            };
-        });
-
-        afterEach(() => {
-            delete window.__CANJS_DEVTOOLS__;
-            $0 = null;
-        });
-
-        describe("can be created with expression", () => {
-            it("hobbies.length", () => {
-                let devtoolsVM = new (DefineMap.extend("DevtoolsVM", {
-                    hobbies: { Default: DefineList }
-                }));
-
-                $0[Symbol.for('can.viewModel')] = devtoolsVM;
-
-                let str = helpers.getBreakpointEvalString({
-                    expression: "hobbies.length",
-                    debuggerStatement: "mock._debugger"
-                });
-                let breakpoint = eval( str );
-
-                assert.equal(breakpoint.expression, "DevtoolsVM{}.hobbies.length");
-                assert.equal(Reflect.getValue(breakpoint.observation), devtoolsVM.hobbies.length, "obs === hobbies.length");
-
-                Reflect.onValue(breakpoint.observation, () => {});
-
-                devtoolsVM.hobbies.push("skiing");
-                assert.equal(debuggerHitCount, 1, "debugger hit once");
-
-                devtoolsVM.hobbies.push("badminton");
-                assert.equal(debuggerHitCount, 2, "debugger hit again");
-            });
-
-            it("hobbies.length > 1", () => {
-                let devtoolsVM = new (DefineMap.extend("DevtoolsVM", {
-                    hobbies: { Default: DefineList }
-                }));
-
-                $0[Symbol.for('can.viewModel')] = devtoolsVM;
-
-                let str = helpers.getBreakpointEvalString({
-                    expression: "hobbies.length > 1",
-                    debuggerStatement: "mock._debugger"
-                });
-                let breakpoint = eval( str );
-
-                assert.equal(breakpoint.expression, "DevtoolsVM{}.hobbies.length > 1");
-                assert.equal(Reflect.getValue(breakpoint.observation), false, "obs === false");
-
-                Reflect.onValue(breakpoint.observation, () => {});
-
-                devtoolsVM.hobbies.push("skiing");
-                assert.equal(debuggerHitCount, 0, "debugger not hit");
-
-                devtoolsVM.hobbies.push("badminton");
-                assert.equal(debuggerHitCount, 1, "debugger hit once");
-
-                devtoolsVM.hobbies.push("luge");
-                assert.equal(debuggerHitCount, 1, "debugger not hit again");
-            });
-
-            it("hobbies.length > counter", () => {
-                let devtoolsVM = new (DefineMap.extend("DevtoolsVM", {
-                    hobbies: { Default: DefineList },
-                    counter: { default: 2 }
-                }));
-
-                $0[Symbol.for('can.viewModel')] = devtoolsVM;
-
-                let str = helpers.getBreakpointEvalString({
-                    expression: "hobbies.length > counter",
-                    debuggerStatement: "mock._debugger"
-                });
-                let breakpoint = eval( str );
-
-                assert.equal(breakpoint.expression, "DevtoolsVM{}.hobbies.length > DevtoolsVM{}.counter");
-                assert.equal(Reflect.getValue(breakpoint.observation), false, "has correct value");
-
-                Reflect.onValue(breakpoint.observation, () => {});
-
-                devtoolsVM.hobbies.push("skiing");
-                assert.equal(debuggerHitCount, 0, "debugger not hit");
-
-                devtoolsVM.hobbies.push("badminton");
-                assert.equal(debuggerHitCount, 0, "debugger still not hit");
-
-                devtoolsVM.hobbies.push("curling");
-                assert.equal(debuggerHitCount, 1, "debugger hit");
-
-                devtoolsVM.hobbies.push("fencing");
-                assert.equal(debuggerHitCount, 1, "debugger not hit again");
-            });
-
-            it("returns an error if no componentelement is selected", () => {
-                window.__CANJS_DEVTOOLS__.$0 = null;
-
-                let str = helpers.getBreakpointEvalString({
-                    expression: "hobbies.length",
-                    debuggerStatement: "mock._debugger"
-                });
-                let breakpoint = eval( str );
-
-                assert.equal(breakpoint.error, "Please select a component in order to create a mutation breakpoint for its ViewModel");
-            });
-
-            it("hobbies.length works when hobbies does not exist", () => {
-                let devtoolsVM = new (DefineMap.extend("DevtoolsVM", {
-                    hobbies: { Type: DefineList }
-                }));
-
-                $0[Symbol.for('can.viewModel')] = devtoolsVM;
-
-                let str = helpers.getBreakpointEvalString({
-                    expression: "hobbies.length",
-                    debuggerStatement: "mock._debugger"
-                });
-                let breakpoint = eval( str );
-
-                assert.equal(breakpoint.expression, "DevtoolsVM{}.hobbies.length");
-                assert.equal(Reflect.getValue(breakpoint.observation), undefined, "obs === undefined");
-
-                Reflect.onValue(breakpoint.observation, () => {});
-
-                devtoolsVM.hobbies = [];
-                assert.equal(debuggerHitCount, 1, "debugger hit once");
-
-                devtoolsVM.hobbies.push("skiing");
-                assert.equal(debuggerHitCount, 2, "debugger hit again");
-
-                devtoolsVM.hobbies = [ "dancing" ];
-                assert.equal(debuggerHitCount, 3, "debugger hit when list changes to new list of same length");
-            });
-        });
-
-        describe("can be restored with expression", () => {
-            beforeEach(() => {
-                const $0 = devtools.$0;
-                delete devtools.$0;
-                devtools.getComponentByPath = () => {
-                    return $0;
-                };
-            });
-
-            afterEach(() => {
-                delete devtools.getComponentByPath;
-            });
-
-            it("hobbies.length", () => {
-                let devtoolsVM = new (DefineMap.extend("DevtoolsVM", {
-                    hobbies: { Default: DefineList }
-                }));
-
-                $0[Symbol.for('can.viewModel')] = devtoolsVM;
-
-                let str = helpers.getBreakpointEvalString({
-                    expression: "DevtoolsVM{}.hobbies.length",
-                    displayExpression: "DevtoolsVM{}.hobbies.length",
-                    selectedComponentStatement: 'window.__CANJS_DEVTOOLS__.getComponentByPath("0")',
-                    observationExpression: "(vm.hobbies && vm.hobbies.length)",
-                    debuggerStatement: "mock._debugger"
-                });
-                let breakpoint = eval( str );
-
-                assert.equal(breakpoint.expression, "DevtoolsVM{}.hobbies.length");
-                assert.equal(Reflect.getValue(breakpoint.observation), devtoolsVM.hobbies.length, "obs === hobbies.length");
-
-                Reflect.onValue(breakpoint.observation, () => {});
-
-                devtoolsVM.hobbies.push("skiing");
-                assert.equal(debuggerHitCount, 1, "debugger hit once");
-
-                devtoolsVM.hobbies.push("badminton");
-                assert.equal(debuggerHitCount, 2, "debugger hit again");
-            });
-        });
-    });
-
-    it("getObservationExpression", () => {
-        [
-            [ "hobbies", "vm.hobbies" ],
-            [ "hobbies.length", "(vm.hobbies && vm.hobbies.length)" ],
-            [ "hobbies.length > 1", "(vm.hobbies && vm.hobbies.length) > 1" ],
-            [ "hobbies.length > counter", "(vm.hobbies && vm.hobbies.length) > vm.counter" ],
-        ].forEach(([ input, expected]) => {
-            assert.equal(
-                helpers.getObservationExpression(input),
-                expected,
-                `helpers.getObservationExpression(${input}) === ${expected}`
-            );
-        });
-    });
+	let helpers, windowChrome, chrome;
+
+	beforeEach(done => {
+		// store original chrome api (it probably doesn't exist)
+		windowChrome = window.chrome;
+
+		chrome = {
+			devtools: {},
+			runtime: {
+				onMessage: { addListener() {} },
+				connect() {
+					return { postMessage() {} };
+				}
+			}
+		};
+		window.chrome = chrome;
+
+		steal.import("canjs-devtools-helpers.mjs").then(mod => {
+			helpers = mod.default;
+			done();
+		});
+	});
+
+	afterEach(() => {
+		window.chrome = windowChrome;
+	});
+
+	describe("runDevtoolsFunction", () => {
+		let evalCalls;
+
+		beforeEach(() => {
+			evalCalls = [];
+
+			chrome.devtools = {
+				inspectedWindow: {
+					eval(fnString, options, callback) {
+						evalCalls.push({
+							fnString: fnString.split("__CANJS_DEVTOOLS__.")[1],
+							url: options.frameURL
+						});
+
+						// call success/error callback to make sure refresh happens
+						callback();
+					}
+				}
+			};
+		});
+
+		it("makes an eval call to each registered frame", () => {
+			helpers.registeredFrames = { "www.one.com": true, "www.two.com": true };
+
+			const teardown = helpers.runDevtoolsFunction({
+				fnString: "fooBar()"
+			});
+
+			assert.equal(evalCalls.length, 2);
+
+			assert.equal(evalCalls[0].fnString, "fooBar()");
+			assert.equal(evalCalls[0].url, "www.one.com");
+
+			assert.equal(evalCalls[1].fnString, "fooBar()");
+			assert.equal(evalCalls[1].url, "www.two.com");
+
+			// clean up frameChangeHandlers so this doesn't break other tests
+			teardown();
+		});
+
+		it("refreshes data every refreshInterval for frames that are still active", done => {
+			const refreshInterval = 5;
+			const refreshAllInterval = 10;
+
+			helpers.registeredFrames = {};
+
+			const teardown = helpers.runDevtoolsFunction({
+				fnString: "fooBar()",
+				refreshInterval,
+				refreshAllInterval
+			});
+
+			assert.equal(
+				evalCalls.length,
+				0,
+				"should not call eval if there are no frames"
+			);
+
+			helpers.registeredFrames = { "www.one.com": true, "www.two.com": true };
+
+			assert.equal(
+				evalCalls.length,
+				2,
+				"when frames change, should call eval for each frame"
+			);
+
+			assert.equal(evalCalls[0].fnString, "fooBar()");
+			assert.equal(evalCalls[0].url, "www.one.com");
+
+			assert.equal(evalCalls[1].fnString, "fooBar()");
+			assert.equal(evalCalls[1].url, "www.two.com");
+
+			setTimeout(() => {
+				assert.equal(
+					evalCalls.length,
+					4,
+					"should refresh data every refresh interval"
+				);
+
+				assert.equal(evalCalls[2].fnString, "fooBar()");
+				assert.equal(evalCalls[2].url, "www.one.com");
+
+				assert.equal(evalCalls[3].fnString, "fooBar()");
+				assert.equal(evalCalls[3].url, "www.two.com");
+
+				// remove second frame
+				helpers.registeredFrames = { "www.one.com": true };
+
+				assert.equal(
+					evalCalls.length,
+					5,
+					"should not refresh data for removed frame"
+				);
+
+				assert.equal(evalCalls[4].fnString, "fooBar()");
+				assert.equal(evalCalls[4].url, "www.one.com");
+
+				// replace frame with a new one
+				helpers.registeredFrames = { "www.three.com": true };
+
+				assert.equal(evalCalls.length, 6, "should load data for new frame");
+
+				assert.equal(evalCalls[5].fnString, "fooBar()");
+				assert.equal(evalCalls[5].url, "www.three.com");
+
+				// stop refreshing so this doesn't break other tests
+				teardown();
+				done();
+			}, refreshInterval);
+		});
+	});
+
+	describe("getBreakpointEvalString", () => {
+		// eslint-disable-next-line
+		let $0, devtools, debuggerHitCount, mock;
+
+		beforeEach(() => {
+			$0 = { [Symbol.for("can.viewModel")]: {} };
+
+			devtools = {
+				$0,
+				canReflect: Reflect,
+				canObservation: Observation,
+				canQueues: queues,
+				register() {}
+			};
+
+			window.__CANJS_DEVTOOLS__ = devtools;
+
+			// mock debugger so we can track when it is read
+			debuggerHitCount = 0;
+			mock = {
+				get _debugger() {
+					return debuggerHitCount++;
+				}
+			};
+		});
+
+		afterEach(() => {
+			delete window.__CANJS_DEVTOOLS__;
+			$0 = null;
+		});
+
+		describe("can be created with expression", () => {
+			it("hobbies.length", () => {
+				class DevtoolsVM extends ObservableObject {
+					static get props() {
+						return {
+							hobbies: {
+								get default() {
+									return new ObservableArray();
+								}
+							}
+						};
+					}
+				}
+
+				let devtoolsVM = new DevtoolsVM();
+				$0[Symbol.for("can.viewModel")] = devtoolsVM;
+
+				let str = helpers.getBreakpointEvalString({
+					expression: "hobbies.length",
+					debuggerStatement: "mock._debugger"
+				});
+				let breakpoint = eval(str);
+
+				assert.equal(breakpoint.expression, "DevtoolsVM{}.hobbies.length");
+				assert.equal(
+					Reflect.getValue(breakpoint.observation),
+					devtoolsVM.hobbies.length,
+					"obs === hobbies.length"
+				);
+
+				Reflect.onValue(breakpoint.observation, () => {});
+
+				devtoolsVM.hobbies.push("skiing");
+				assert.equal(debuggerHitCount, 1, "debugger hit once");
+
+				devtoolsVM.hobbies.push("badminton");
+				assert.equal(debuggerHitCount, 2, "debugger hit again");
+			});
+
+			it("hobbies.length > 1", () => {
+				class DevtoolsVM extends ObservableObject {
+					static get props() {
+						return {
+							hobbies: {
+								get default() {
+									return new ObservableArray();
+								}
+							}
+						};
+					}
+				}
+
+				let devtoolsVM = new DevtoolsVM();
+				$0[Symbol.for("can.viewModel")] = devtoolsVM;
+
+				let str = helpers.getBreakpointEvalString({
+					expression: "hobbies.length > 1",
+					debuggerStatement: "mock._debugger"
+				});
+				let breakpoint = eval(str);
+
+				assert.equal(breakpoint.expression, "DevtoolsVM{}.hobbies.length > 1");
+				assert.equal(
+					Reflect.getValue(breakpoint.observation),
+					false,
+					"obs === false"
+				);
+
+				Reflect.onValue(breakpoint.observation, () => {});
+
+				devtoolsVM.hobbies.push("skiing");
+				assert.equal(debuggerHitCount, 0, "debugger not hit");
+
+				devtoolsVM.hobbies.push("badminton");
+				assert.equal(debuggerHitCount, 1, "debugger hit once");
+
+				devtoolsVM.hobbies.push("luge");
+				assert.equal(debuggerHitCount, 1, "debugger not hit again");
+			});
+
+			it("hobbies.length > counter", () => {
+				class DevtoolsVM extends ObservableObject {
+					static get props() {
+						return {
+							hobbies: {
+								get default() {
+									return new ObservableArray();
+								}
+							},
+							counter: { default: 2 }
+						};
+					}
+				}
+
+				let devtoolsVM = new DevtoolsVM();
+				$0[Symbol.for("can.viewModel")] = devtoolsVM;
+
+				let str = helpers.getBreakpointEvalString({
+					expression: "hobbies.length > counter",
+					debuggerStatement: "mock._debugger"
+				});
+				let breakpoint = eval(str);
+
+				assert.equal(
+					breakpoint.expression,
+					"DevtoolsVM{}.hobbies.length > DevtoolsVM{}.counter"
+				);
+				assert.equal(
+					Reflect.getValue(breakpoint.observation),
+					false,
+					"has correct value"
+				);
+
+				Reflect.onValue(breakpoint.observation, () => {});
+
+				devtoolsVM.hobbies.push("skiing");
+				assert.equal(debuggerHitCount, 0, "debugger not hit");
+
+				devtoolsVM.hobbies.push("badminton");
+				assert.equal(debuggerHitCount, 0, "debugger still not hit");
+
+				devtoolsVM.hobbies.push("curling");
+				assert.equal(debuggerHitCount, 1, "debugger hit");
+
+				devtoolsVM.hobbies.push("fencing");
+				assert.equal(debuggerHitCount, 1, "debugger not hit again");
+			});
+
+			it("returns an error if no component is selected", () => {
+				window.__CANJS_DEVTOOLS__.$0 = null;
+
+				let str = helpers.getBreakpointEvalString({
+					expression: "hobbies.length",
+					debuggerStatement: "mock._debugger"
+				});
+				let breakpoint = eval(str);
+
+				assert.equal(
+					breakpoint.error,
+					"Please select a component in order to create a mutation breakpoint for its ViewModel"
+				);
+			});
+
+			it("hobbies.length works when hobbies does not exist", () => {
+				class DevtoolsVM extends ObservableObject {
+					static get props() {
+						return {
+							hobbies: type.convert(ObservableArray)
+						};
+					}
+				}
+
+				let devtoolsVM = new DevtoolsVM();
+				$0[Symbol.for("can.viewModel")] = devtoolsVM;
+
+				let str = helpers.getBreakpointEvalString({
+					expression: "hobbies.length",
+					debuggerStatement: "mock._debugger"
+				});
+				let breakpoint = eval(str);
+
+				assert.equal(breakpoint.expression, "DevtoolsVM{}.hobbies.length");
+				assert.equal(
+					Reflect.getValue(breakpoint.observation),
+					undefined,
+					"obs === undefined"
+				);
+
+				Reflect.onValue(breakpoint.observation, () => {});
+
+				devtoolsVM.hobbies = [];
+				assert.equal(debuggerHitCount, 1, "debugger hit once");
+
+				devtoolsVM.hobbies.push("skiing");
+				assert.equal(debuggerHitCount, 2, "debugger hit again");
+
+				devtoolsVM.hobbies = ["dancing"];
+				assert.equal(
+					debuggerHitCount,
+					3,
+					"debugger hit when list changes to new list of same length"
+				);
+			});
+		});
+
+		describe("can be restored with expression", () => {
+			beforeEach(() => {
+				const $0 = devtools.$0;
+				delete devtools.$0;
+				devtools.getComponentByPath = () => {
+					return $0;
+				};
+			});
+
+			afterEach(() => {
+				delete devtools.getComponentByPath;
+			});
+
+			it("hobbies.length", () => {
+				class DevtoolsVM extends ObservableObject {
+					static get props() {
+						return {
+							hobbies: {
+								get default() {
+									return new ObservableArray();
+								}
+							}
+						};
+					}
+				}
+
+				let devtoolsVM = new DevtoolsVM();
+				$0[Symbol.for("can.viewModel")] = devtoolsVM;
+
+				let str = helpers.getBreakpointEvalString({
+					expression: "DevtoolsVM{}.hobbies.length",
+					displayExpression: "DevtoolsVM{}.hobbies.length",
+					selectedComponentStatement:
+						'window.__CANJS_DEVTOOLS__.getComponentByPath("0")',
+					observationExpression: "(vm.hobbies && vm.hobbies.length)",
+					debuggerStatement: "mock._debugger"
+				});
+				let breakpoint = eval(str);
+
+				assert.equal(breakpoint.expression, "DevtoolsVM{}.hobbies.length");
+				assert.equal(
+					Reflect.getValue(breakpoint.observation),
+					devtoolsVM.hobbies.length,
+					"obs === hobbies.length"
+				);
+
+				Reflect.onValue(breakpoint.observation, () => {});
+
+				devtoolsVM.hobbies.push("skiing");
+				assert.equal(debuggerHitCount, 1, "debugger hit once");
+
+				devtoolsVM.hobbies.push("badminton");
+				assert.equal(debuggerHitCount, 2, "debugger hit again");
+			});
+		});
+	});
+
+	it("getObservationExpression", () => {
+		[
+			["hobbies", "vm.hobbies"],
+			["hobbies.length", "(vm.hobbies && vm.hobbies.length)"],
+			["hobbies.length > 1", "(vm.hobbies && vm.hobbies.length) > 1"],
+			[
+				"hobbies.length > counter",
+				"(vm.hobbies && vm.hobbies.length) > vm.counter"
+			]
+		].forEach(([input, expected]) => {
+			assert.equal(
+				helpers.getObservationExpression(input),
+				expected,
+				`helpers.getObservationExpression(${input}) === ${expected}`
+			);
+		});
+	});
 });

--- a/test/injected-script-test.js
+++ b/test/injected-script-test.js
@@ -400,15 +400,11 @@ describe("canjs-devtools-injected-script", () => {
 							}
 						},
 						emptyObject: {
-							type: type.Any,
-
 							get default() {
 								return {};
 							}
 						},
 						emptyArray: {
-							type: type.Any,
-
 							get default() {
 								return [];
 							}
@@ -784,8 +780,6 @@ describe("canjs-devtools-injected-script", () => {
 						return this.first + " " + this.last;
 					},
 					hobbies: {
-						type: type.Any,
-
 						get default() {
 							return ["running", "jumping"];
 						}

--- a/test/injected-script-test.js
+++ b/test/injected-script-test.js
@@ -1,1033 +1,1359 @@
-import mocha from "steal-mocha";
-import chai from "chai/chai";
+import { assert } from "chai/chai";
+import "steal-mocha";
 
-import { Component, DefineMap, DefineList, debug, Reflect, Observation } from "can";
+import {
+	debug,
+	DeepObservable,
+	ObservableArray,
+	ObservableObject,
+	Observation,
+	Reflect,
+	StacheElement,
+	type
+} from "can";
 import "../canjs-devtools-injected-script";
 
-const assert = chai.assert;
-
-const isElement = (el) => el.toString() === "[object HTMLElement]";
+const isElement = el => el.toString() === "[object HTMLElement]";
 
 describe("canjs-devtools-injected-script", () => {
-    let devtools, windowCan;
-
-    before(() => {
-        // register devtools
-        debug();
-
-        // make sure devtools is not using global `can`
-        windowCan = window.can;
-        delete window.can;
-
-        // get access to devtools functions
-        devtools = window.__CANJS_DEVTOOLS__;
-    });
-
-    after(() => {
-        window.can = windowCan;
-    });
-
-    describe("getViewModelData", () => {
-        it("basics", () => {
-            const C = Component.extend({
-                tag: "a-pp",
-                view: "<p>{{name}}</p>",
-                ViewModel: {
-                    first: { type: "string", default: "Kevin" },
-                    last: { type: "string", default: "McCallister" },
-                    get name() {
-                        return this.first + " " + this.last;
-                    }
-                }
-            });
-
-            const c = new C();
-            const el = c.element;
-
-            const {
-                viewModelData: viewModelDataFromEl,
-                tagName: tagNameFromEl,
-                type: typeFromEl,
-                typeNames: typeNamesFromEl
-            } = devtools.getViewModelData(el).detail;
-
-            assert.equal(tagNameFromEl, "<a-pp>", "tagName from el");
-            assert.deepEqual(
-                viewModelDataFromEl,
-                { first: "Kevin", last: "McCallister", name: "Kevin McCallister" },
-                "viewModelData from el"
-            );
-            assert.deepEqual(
-                typeNamesFromEl,
-                {},
-                "typeNames from el"
-            );
-
-            const {
-                viewModelData: viewModelDataFromChild,
-                tagName: tagNameFromChild,
-                type: typeFromChild,
-                typeNames: typeNamesFromChild
-            } = devtools.getViewModelData(el.querySelector("p")).detail;
-
-            assert.equal(tagNameFromChild, "<a-pp>", "tagName from child of el");
-            assert.deepEqual(
-                viewModelDataFromChild,
-                { first: "Kevin", last: "McCallister", name: "Kevin McCallister" },
-                "viewModelData from child of el"
-            );
-            assert.deepEqual(
-                typeNamesFromChild,
-                {},
-                "typeNames from child of el"
-            );
-        });
-
-        it("can handle elements", () => {
-            const C = Component.extend({
-                tag: "app-with-element",
-                view: "<p>this app has an element on its viewModelData</p>",
-                ViewModel: {
-                    element: {
-                        default() {
-                            return document.createElement("p");
-                        }
-                    }
-                }
-            });
-
-            const c = new C();
-            const el = c.element;
-
-            const {
-                viewModelData,
-                typeNames,
-                messages
-            } = devtools.getViewModelData(el).detail;
-
-            assert.deepEqual(
-                viewModelData,
-                { element: {} },
-                "gets correct viewModelData data"
-            );
-
-            assert.deepEqual(
-                typeNames,
-                { element: "HTMLParagraphElement{}" },
-                "gets correct name data"
-            );
-
-            assert.deepEqual(
-                messages,
-                { element: { type: "info", message: "CanJS Devtools does not expand HTML Elements" } },
-                "gets correct message data"
-            );
-        });
-
-        it("can handle lists of elements", () => {
-            const C = Component.extend({
-                tag: "app-with-list-of-elements",
-                view: "<p>this app has a list of elements on its viewModel</p>",
-                ViewModel: {
-                    elements: {
-                        default() {
-                            return new DefineList([
-                                document.createElement("p"),
-                                document.createElement("p")
-                            ]);
-                        }
-                    }
-                }
-            });
-
-            const c = new C();
-            const el = c.element;
-
-            const {
-                viewModelData,
-                typeNames,
-                messages
-            } = devtools.getViewModelData(el).detail;
-
-            assert.deepEqual(
-                viewModelData,
-                { elements: { } },
-                "gets correct viewModelData data - unexpanded"
-            );
-
-            assert.deepEqual(
-                typeNames,
-                { elements: "DefineList[]" },
-                "gets correct name data - unexpanded"
-            );
-
-            assert.deepEqual(
-                messages,
-                {},
-                "gets correct message data - unexpanded"
-            );
-
-            const {
-                viewModelData: viewModelDataListExpanded,
-                typeNames: typeNamesListExpanded,
-                messages: messagesListExpanded
-            } = devtools.getViewModelData(el, { expandedKeys: [ "elements" ] }).detail;
-
-            assert.deepEqual(
-                viewModelDataListExpanded,
-                { elements: { 0: { }, 1: { } } },
-                "gets correct viewModelData data - list expanded"
-            );
-
-            assert.deepEqual(
-                typeNamesListExpanded,
-                {
-                    elements: "DefineList[]",
-                    "elements.0": "HTMLParagraphElement{}",
-                    "elements.1": "HTMLParagraphElement{}"
-                },
-                "gets correct name data - list expanded"
-            );
-
-            assert.deepEqual(
-                messagesListExpanded,
-                {
-                    "elements.0": { type: "info", message: "CanJS Devtools does not expand HTML Elements" },
-                    "elements.1": { type: "info", message: "CanJS Devtools does not expand HTML Elements" },
-                },
-                "gets correct message data - list expanded"
-            );
-        });
-
-        it("can handle functions", () => {
-            const C = Component.extend({
-                tag: "app-with-functions",
-                view: "<p>this app uses functions</p>",
-                ViewModel: {
-                    Thing: {
-                        default: () => function Thing() {}
-                    }
-                }
-            });
-
-            const c = new C();
-            const el = c.element;
-
-            const {
-                viewModelData,
-                typeNames,
-                messages
-            } = devtools.getViewModelData(el).detail;
-
-            assert.deepEqual(
-                viewModelData,
-                { Thing: { } },
-                "shows an empty object for function so it can be expanded to show function source"
-            );
-
-            assert.deepEqual(
-                typeNames,
-                { Thing: "function" },
-                "shows correct name for function"
-            );
-
-            assert.deepEqual(
-                messages,
-                { Thing: { type: "info", message: "function Thing() {}" } },
-                "shows function source info message"
-            );
-        });
-
-        it("can handle circular references (#46)", () => {
-            const circular = {};
-            circular.circular = circular;
-
-            const C = Component.extend({
-                tag: "circular-app",
-                view: "<p>hello</p>",
-                ViewModel: {
-                    circular: {
-                        default: () => circular
-                    }
-                }
-            });
-
-            const c = new C();
-            const el = c.element;
-
-            const {
-                viewModelData,
-                typeNames,
-                messages
-            } = devtools.getViewModelData(el).detail;
-
-            assert.deepEqual(
-                viewModelData,
-                { circular: { } },
-                "gets empty object for circular property"
-            );
-
-            assert.deepEqual(
-                typeNames,
-                { circular: "Object{}" },
-                "gets correct name for circular property"
-            );
-
-            assert.equal(typeof messages, "object");
-            assert.equal(typeof messages.circular, "object");
-            assert.equal(messages.circular.type, "error");
-            assert.ok(messages.circular.message.match(/Error getting value of "circular":/))
-        });
-
-        it("can handle infinite recursion (#46)", () => {
-            const Thing = DefineMap.extend("Thing", {
-                anotherThing: {
-                    default() {
-                        return new Thing();
-                    }
-                }
-            });
-
-            const C = Component.extend({
-                tag: "circular-app",
-                view: "<p>hello</p>",
-                ViewModel: {
-                    thing: { Default: Thing }
-                }
-            });
-
-            const c = new C();
-            const el = c.element;
-
-            const {
-                viewModelData,
-                typeNames
-            } = devtools.getViewModelData(el).detail;
-
-            assert.deepEqual(
-                viewModelData,
-                { thing: { } },
-                "gets empty object for recursive property"
-            );
-
-            assert.deepEqual(
-                typeNames,
-                { thing: "Thing{}" },
-                "gets correct name"
-            );
-        });
-
-        it("can handle nulls and undefineds", () => {
-            const C = Component.extend({
-                tag: "app-with-nulls",
-                view: "<p>hello</p>",
-                ViewModel: {
-                    thisIsNull: { default: null },
-                    thisIsUndefined: { default: undefined }
-                }
-            });
-
-            const c = new C();
-            const el = c.element;
-
-            const {
-                viewModelData,
-                typeNames,
-                messages,
-                undefineds
-            } = devtools.getViewModelData(el).detail;
-
-            assert.deepEqual(
-                viewModelData,
-                { thisIsNull: null, thisIsUndefined: undefined },
-                "gets null for property that is null and undefined for property that is undefined"
-            );
-
-            assert.deepEqual(
-                undefineds,
-                [ "thisIsUndefined" ],
-                "gets undefineds array with paths whose value is `undefined`"
-            );
-
-            assert.deepEqual(
-                messages,
-                { },
-                "gets no messages"
-            );
-        });
-
-        it("can handle empty Maps / Lists / Objects / arrays", () => {
-            const C = Component.extend({
-                tag: "app-with-empties",
-                view: "<p>hello</p>",
-                ViewModel: {
-                    emptyMap: { Default: DefineMap },
-                    emptyList: { Default: DefineList },
-                    emptyObject: {
-                        type: "any",
-                        default() {
-                            return {};
-                        }
-                    },
-                    emptyArray: {
-                        type: "any",
-                        default() {
-                            return [];
-                        }
-                    }
-                }
-            });
-
-            const c = new C();
-            const el = c.element;
-
-            const {
-                viewModelData,
-                typeNames,
-                messages
-            } = devtools.getViewModelData(el, { expandedKeys: [ "emptyMap", "emptyList", "emptyObject", "emptyArray" ] }).detail;
-
-            assert.deepEqual(
-                viewModelData,
-                {
-                    emptyMap: {},
-                    emptyList: {},
-                    emptyObject: {},
-                    emptyArray: {}
-                },
-                "viewModelData properties are correct"
-            );
-
-            assert.deepEqual(
-                typeNames,
-                {
-                    emptyMap: "DefineMap{}",
-                    emptyList: "DefineList[]",
-                    emptyObject: "Object{}",
-                    emptyArray: "Array[]"
-                },
-                "typeNames are correct"
-            );
-
-            assert.deepEqual(
-                messages,
-                {
-                    emptyMap: { type: "info", message: "Map is empty" },
-                    emptyList: { type: "info", message: "List is empty" },
-                    emptyObject: { type: "info", message: "Object is empty" },
-                    emptyArray: { type: "info", message: "Array is empty" }
-                },
-                "gets correct messages"
-            );
-        });
-    });
-
-    it("getNearestElementWithViewModel", () => {
-        const C = Component.extend({
-            tag: "a-pp",
-            view: "<p>{{name}}</p>",
-            ViewModel: { }
-        });
-
-        const c = new C();
-        const el = c.element;
-
-        assert.deepEqual(
-            devtools.getNearestElementWithViewModel(el),
-            el,
-            "gets element from element with a viewmodel"
-        );
-
-        assert.deepEqual(
-            devtools.getNearestElementWithViewModel(el.querySelector("p")),
-            el,
-            "gets element from child of element with a viewmodel"
-        );
-
-    });
-
-    describe("getSerializedViewModelData", () => {
-        it("viewModelData", () => {
-            let VM = DefineMap.extend({
-                name: "string"
-            });
-
-            assert.deepEqual(
-                devtools.getSerializedViewModelData(new VM()).viewModelData,
-                { name: undefined },
-                "works for basic ViewModel"
-            );
-
-            VM = DefineMap.extend({
-                first: { type: "string", default: "Kevin" },
-                last: { type: "string", default: "McCallister" },
-                get name() {
-                    return this.first + " " + this.last;
-                }
-            });
-
-            assert.deepEqual(
-                devtools.getSerializedViewModelData(new VM()).viewModelData,
-                { first: "Kevin", last: "McCallister", name: "Kevin McCallister" },
-                "works for ViewModel with serialized properties"
-            );
-
-            VM = DefineMap.extend({
-                hobbies: {
-                    default() {
-                        return [{ name: "singing" }, { name: "dancing" }];
-                    }
-                }
-            });
-
-            assert.deepEqual(
-                devtools.getSerializedViewModelData(new VM()).viewModelData,
-                { hobbies: { } },
-                "works for DefineMap with nested array - unexpanded"
-            );
-
-            assert.deepEqual(
-                devtools.getSerializedViewModelData(new VM(), { expandedKeys: [ "hobbies" ] }).viewModelData,
-                { hobbies: { 0: { }, 1: { } } },
-                "works for DefineMap with nested array - array expanded"
-            );
-
-            assert.deepEqual(
-                devtools.getSerializedViewModelData(new VM(), { expandedKeys: [ "hobbies", "hobbies.0", "hobbies.1" ] }).viewModelData,
-                { hobbies: { 0: { name: "singing" }, 1: { name: "dancing" } } },
-                "works for DefineMap with nested array - all expanded"
-            );
-
-            VM = DefineMap.extend({
-                hobbies: {
-                    Type: DefineList.extend("Hobbies", {
-                        "#": DefineMap.extend("Hobby", {
-                            name: "string"
-                        })
-                    }),
-                    default() {
-                        return [{ name: "singing" }, { name: "dancing" }];
-                    }
-                }
-            });
-
-            assert.deepEqual(
-                devtools.getSerializedViewModelData(new VM()).viewModelData,
-                { hobbies: { } },
-                "works for nested DefineMaps - unexpanded"
-            );
-
-            assert.deepEqual(
-                devtools.getSerializedViewModelData(new VM(), { expandedKeys: [ "hobbies" ] }).viewModelData,
-                { hobbies: { 0: { }, 1: { } } },
-                "works for nested DefineMaps - array expanded"
-            );
-
-            assert.deepEqual(
-                devtools.getSerializedViewModelData(new VM(), { expandedKeys: [ "hobbies", "hobbies.0", "hobbies.1" ] }).viewModelData,
-                { hobbies: { 0: { name: "singing" }, 1: { name: "dancing" } } },
-                "works for nested DefineMaps - everything expanded"
-            );
-            var PersonName = DefineMap.extend("Name", {
-              first: { type: "string", default: "kevin" },
-              last: { type: "string", default: "phillips" }
-            });
-
-            VM = DefineMap.extend("Person", {
-              name: { Default: PersonName },
-              age: { default: 32 }
-            });
-
-            assert.deepEqual(
-                devtools.getSerializedViewModelData(new VM()).viewModelData,
-                { age: 32, name: {} },
-                "only serializes top-level properties by default"
-            );
-        });
-
-        it("typeNames", () => {
-            const Thing = DefineMap.extend("AThing", {});
-
-            let ViewModel = DefineMap.extend("ViewModel", {
-                aThing: { Type: Thing, Default: Thing }
-            });
-
-            assert.deepEqual(
-                devtools.getSerializedViewModelData(new ViewModel()).typeNames,
-                { aThing: "AThing{}" },
-                "AThing{} - nothing expanded"
-            );
-
-            const ListOfThings = DefineList.extend("ListOfThings", {
-                "#": Thing
-            });
-
-            ViewModel = DefineMap.extend("ViewModel", {
-                things: { Type: ListOfThings, default: () => [{}] }
-            });
-
-            assert.deepEqual(
-                devtools.getSerializedViewModelData(new ViewModel()).typeNames,
-                { things: "ListOfThings[]" },
-                "ListOfThings[] - nothing expanded"
-            );
-
-            assert.deepEqual(
-                devtools.getSerializedViewModelData(new ViewModel(), { expandedKeys: [ "things" ] }).typeNames,
-                { things: "ListOfThings[]", "things.0": "AThing{}" },
-                "ListOfThings[] - list expanded"
-            );
-
-            const Name = DefineMap.extend("Name", {});
-            const NamedThing = DefineMap.extend("NamedThing", {
-                name: Name
-            });
-            const ListOfNamedThings = DefineList.extend("ListOfNamedThings", {
-                "#": NamedThing
-            });
-
-            ViewModel = DefineMap.extend("ViewModel", {
-                things: { Type: ListOfNamedThings, default: () => [{ name: {} }] }
-            });
-
-            assert.deepEqual(
-                devtools.getSerializedViewModelData(new ViewModel()).typeNames,
-                { things: "ListOfNamedThings[]" },
-                "ListOfNamedThings[] - nothing expanded"
-            );
-            assert.deepEqual(
-                devtools.getSerializedViewModelData(new ViewModel(), { expandedKeys: [ "things" ] }).typeNames,
-                { things: "ListOfNamedThings[]", "things.0": "NamedThing{}" },
-                "ListOfNamedThings[] - list expanded"
-            );
-            assert.deepEqual(
-                devtools.getSerializedViewModelData(new ViewModel(), { expandedKeys: [ "things", "things.0" ] }).typeNames,
-                { things: "ListOfNamedThings[]", "things.0": "NamedThing{}", "things.0.name": "Name{}" },
-                "ListOfNamedThings[] - everything expanded"
-            );
-        });
-
-        it("undefineds", () => {
-            const ViewModel = DefineMap.extend({
-                thisIsUndefined: { default: undefined },
-                obj: {
-                    Type: DefineMap,
-                    default() {
-                        return {
-                            thisIsUndefined: undefined
-                        };
-                    }
-                }
-            });
-
-            assert.deepEqual(
-                devtools.getSerializedViewModelData(new ViewModel()).undefineds,
-                [ "thisIsUndefined" ],
-                "nothing expanded"
-            );
-
-            assert.deepEqual(
-                devtools.getSerializedViewModelData(new ViewModel(), { expandedKeys: [ "obj" ] }).undefineds,
-                [ "thisIsUndefined", "obj.thisIsUndefined" ],
-                "obj expanded"
-            );
-        });
-    });
-
-    it("updateViewModel", () => {
-        const C = Component.extend({
-            tag: "a-pp",
-            view: "<p>{{name}}</p>",
-            ViewModel: {
-                first: { type: "string", default: "Kevin" },
-                last: { type: "string", default: "McCallister" },
-                get name() {
-                    return this.first + " " + this.last;
-                },
-                hobbies: {
-                    type: "any",
-                    default() {
-                        return [ "running", "jumping" ];
-                    }
-                }
-            }
-        });
-
-        const c = new C();
-        const viewModel = c.viewModel;
-        const el = c.element;
-
-        assert.deepEqual(
-            devtools.getSerializedViewModelData(viewModel, { expandedKeys: [ "hobbies" ] }).viewModelData,
-            { first: "Kevin", last: "McCallister", name: "Kevin McCallister", hobbies: { 0: "running", 1: "jumping" } },
-            "default viewmodel data"
-        );
-
-        devtools.updateViewModel(el, [
-            { type: "set", key: "first", value: "Marty" },
-            { type: "set", key: "last", value: "McFly" }
-        ]);
-
-        assert.deepEqual(
-            devtools.getSerializedViewModelData(viewModel, { expandedKeys: [ "hobbies" ] }).viewModelData,
-            { first: "Marty", last: "McFly", name: "Marty McFly", hobbies: { 0: "running", 1: "jumping" } },
-            "set works"
-        );
-
-        devtools.updateViewModel(el, [
-            { type: "delete", key: "last" }
-        ]);
-
-        assert.deepEqual(
-            devtools.getSerializedViewModelData(viewModel, { expandedKeys: [ "hobbies" ] }).viewModelData,
-            { first: "Marty", last: undefined, name: "Marty undefined", hobbies: { 0: "running", 1: "jumping" } },
-            "delete works"
-        );
-
-        devtools.updateViewModel(el, [
-            { type: "splice", key: "hobbies", index: 0, deleteCount: 1, insert: [ "skipping" ] }
-        ]);
-
-        assert.deepEqual(
-            devtools.getSerializedViewModelData(viewModel, { expandedKeys: [ "hobbies" ] }).viewModelData,
-            { first: "Marty", last: undefined, name: "Marty undefined", hobbies: { 0: "skipping", 1: "jumping" } },
-            "splice works"
-        );
-    });
-
-    it("getViewModelKeys", () => {
-        const C = Component.extend({
-            tag: "a-pp",
-            view: "<p>{{name}}</p>",
-            ViewModel: {
-                first: { type: "string", default: "Kevin" },
-                last: { type: "string", default: "McCallister" },
-                get name() {
-                    return this.first + " " + this.last;
-                }
-            }
-        });
-
-        const c = new C();
-        const viewModel = c.viewModel;
-
-        assert.deepEqual(
-            devtools.getViewModelKeys(viewModel),
-            [ "first", "last", "name" ],
-            "gets viewmodel keys"
-        );
-
-        const list = new DefineList([ { one: "two" }, { three: "four" } ]);
-        assert.deepEqual(
-            devtools.getViewModelKeys(list),
-            [ "0", "1" ],
-            "ignore _ keys for DefineList"
-        );
-    });
-
-    describe("component tree", () => {
-        let appOne, appTwo, appThree, treeData;
-        const fixture = document.getElementById("mocha-fixture");
-
-        // run once before all tests in this describe
-        // so that component IDs do not change between tests
-        before(() => {
-            // <a-pp>
-            //   <div>
-            //      <a-child>
-            //          <a-deep-child/>
-            //      </a-child>
-            //   </div>
-            //   <a-nother-child>
-            //      <p>
-            //          <a-nother-deep-child/>
-            //      </p>
-            //   </a-nother-child>
-            // </a-pp>
-            // <a-pp>
-            //   <div>
-            //      <a-child>
-            //          <a-deep-child/>
-            //      </a-child>
-            //   </div>
-            //   <a-nother-child>
-            //      <p>
-            //          <a-nother-deep-child/>
-            //      </p>
-            //   </a-nother-child>
-            // </a-pp>
-            Component.extend({
-                tag: "a-child",
-                view: "<a-deep-child/>",
-                ViewModel: {}
-            });
-
-            Component.extend({
-                tag: "a-deep-child",
-                view: "<p>a deep child</p>",
-                ViewModel: {}
-            });
-
-            Component.extend({
-                tag: "a-nother-child",
-                view: "<p><a-nother-deep-child/></p>",
-                ViewModel: {}
-            });
-
-            Component.extend({
-                tag: "a-nother-deep-child",
-                view: "<p>another deep child</p>",
-                ViewModel: {}
-            });
-
-            const App = Component.extend({
-                tag: "a-pp",
-                view: `
-                    <div>
-                        <a-child />
-                    </div>
-                    <a-nother-child/>
-                `,
-                ViewModel: {}
-            });
-
-            const a = new App();
-            appOne = a.element;
-
-            const b = new App();
-            appTwo = b.element;
-
-            appThree = document.createElement("aa-pp");
-            appThree[Symbol.for("can.viewModel")] = appThree;
-            
-            fixture.appendChild(appOne);
-            fixture.appendChild(appTwo);
-            fixture.appendChild(appThree);
-            
-            window.$0 = fixture.querySelector("a-nother-deep-child");
-
-            const resp = devtools.getComponentTreeData();
-            treeData = resp.detail.tree;
-        });
-
-        after(() => {
-            fixture.removeChild(appOne);
-            fixture.removeChild(appTwo);
-            fixture.removeChild(appThree);
-        });
-
-        it("getComponentTreeData", () => {
-            assert.deepEqual(treeData, [{
-                path: "0",
-                selected: false,
-                tagName: "a-pp",
-                id: 0,
-                children: [{
-                    path: "0.children.0",
-                    selected: false,
-                    tagName: "a-child",
-                    id: 1,
-                    children: [{
-                        path: "0.children.0.children.0",
-                        selected: false,
-                        tagName: "a-deep-child",
-                        id: 2,
-                        children: []
-                    }]
-                }, {
-                    path: "0.children.1",
-                    selected: false,
-                    tagName: "a-nother-child",
-                    id: 3,
-                    children: [{
-                        path: "0.children.1.children.0",
-                        selected: true,
-                        tagName: "a-nother-deep-child",
-                        id: 4,
-                        children: []
-                    }]
-                }]
-            }, {
-                path: "1",
-                selected: false,
-                tagName: "a-pp",
-                id: 5,
-                children: [{
-                    path: "1.children.0",
-                    selected: false,
-                    tagName: "a-child",
-                    id: 6,
-                    children: [{
-                        path: "1.children.0.children.0",
-                        selected: false,
-                        tagName: "a-deep-child",
-                        id: 7,
-                        children: []
-                    }]
-                }, {
-                    path: "1.children.1",
-                    selected: false,
-                    tagName: "a-nother-child",
-                    id: 8,
-                    children: [{
-                        path: "1.children.1.children.0",
-                        selected: false,
-                        tagName: "a-nother-deep-child",
-                        id: 9,
-                        children: []
-                    }]
-                }]
-            }, {
-                path: "2",
-                selected: false,
-                tagName: "aa-pp",
-                id: 10,
-                children: []
-            }]);
-        });
-
-        it("selectComponentById", () => {
-            devtools.selectComponentById(0);
-            assert.ok(isElement(devtools.$0), "App");
-            assert.equal(devtools.$0.tagName.toLowerCase(), "a-pp", "a-pp");
-
-            devtools.selectComponentById(1);
-            assert.ok(isElement(devtools.$0), "Child");
-            assert.equal(devtools.$0.tagName.toLowerCase(), "a-child", "a-child");
-
-            devtools.selectComponentById(2);
-            assert.ok(isElement(devtools.$0), "DeepChild");
-            assert.equal(devtools.$0.tagName.toLowerCase(), "a-deep-child", "a-deep-child");
-
-            devtools.selectComponentById(3);
-            assert.ok(isElement(devtools.$0), "AnotherChild");
-            assert.equal(devtools.$0.tagName.toLowerCase(), "a-nother-child", "a-nother-child");
-
-            devtools.selectComponentById(4);
-            assert.ok(isElement(devtools.$0), "AnotherDeepChild");
-            assert.equal(devtools.$0.tagName.toLowerCase(), "a-nother-deep-child", "a-nother-deep-child");
-
-            devtools.selectComponentById(5);
-            assert.ok(isElement(devtools.$0), "App");
-            assert.equal(devtools.$0.tagName.toLowerCase(), "a-pp", "second a-pp");
-
-            devtools.selectComponentById(6);
-            assert.ok(isElement(devtools.$0), "Child");
-            assert.equal(devtools.$0.tagName.toLowerCase(), "a-child", "second a-child");
-
-            devtools.selectComponentById(7);
-            assert.ok(isElement(devtools.$0), "DeepChild");
-            assert.equal(devtools.$0.tagName.toLowerCase(), "a-deep-child", "second a-deep-child");
-
-            devtools.selectComponentById(8);
-            assert.ok(isElement(devtools.$0), "AnotherChild");
-            assert.equal(devtools.$0.tagName.toLowerCase(), "a-nother-child", "second a-nother-child");
-
-            devtools.selectComponentById(9);
-            assert.ok(isElement(devtools.$0), "AnotherDeepChild");
-            assert.equal(devtools.$0.tagName.toLowerCase(), "a-nother-deep-child", "second a-nother-deep-child");
-
-            devtools.selectComponentById(10);
-            assert.ok(isElement(devtools.$0), "aa-pp");
-            assert.equal(devtools.$0.tagName.toLowerCase(), "aa-pp", "the element is the viewmodel child");
-        });
-    });
-
-    describe("add / get / toggle / delete breakpoints", () => {
-        it("basics", () => {
-            let breakpoints = devtools.addBreakpoint({
-                expression: "todos.length"
-            }).detail.breakpoints;
-
-            assert.equal(breakpoints.length, 1, "addBreakpoint adds a breakpoint");
-            assert.equal(breakpoints[0].expression, "todos.length", "first breakpoint has correct expression");
-            assert.equal(breakpoints[0].enabled, true, "first breakpoint is enabled");
-
-            const todosLengthBreakpointId = breakpoints[0].id;
-
-            assert.deepEqual(devtools.getBreakpoints().detail.breakpoints, breakpoints, "getBreakpoints works");
-
-            breakpoints = devtools.addBreakpoint({
-                expression: "person.nameChanges > 5"
-            }).detail.breakpoints;
-
-            assert.equal(breakpoints.length, 2, "addBreakpoint adds a second breakpoint");
-            assert.equal(breakpoints[1].expression, "person.nameChanges > 5", "second breakpoint has correct expression");
-            assert.equal(breakpoints[1].enabled, true, "second breakpoint is enabled");
-
-            const nameChangesBreakpointId = breakpoints[1].id;
-
-            assert.deepEqual(devtools.getBreakpoints().detail.breakpoints, breakpoints, "getBreakpoints still works");
-
-            breakpoints = devtools.toggleBreakpoint(todosLengthBreakpointId).detail.breakpoints;
-            assert.equal(breakpoints[0].enabled, false, "breakpoint is disabled");
-            assert.equal(breakpoints[1].enabled, true, "second breakpoint is enabled");
-
-            breakpoints = devtools.toggleBreakpoint(nameChangesBreakpointId).detail.breakpoints;
-            assert.equal(breakpoints[0].enabled, false, "breakpoint is disabled");
-            assert.equal(breakpoints[1].enabled, false, "second breakpoint is disabled");
-
-            breakpoints = devtools.toggleBreakpoint(nameChangesBreakpointId).detail.breakpoints;
-            assert.equal(breakpoints[0].enabled, false, "breakpoint is still disabled");
-            assert.equal(breakpoints[1].enabled, true, "second breakpoint is re-enabled");
-
-            breakpoints = devtools.toggleBreakpoint(todosLengthBreakpointId).detail.breakpoints;
-            assert.equal(breakpoints[0].enabled, true, "breakpoint is re-enabled");
-            assert.equal(breakpoints[1].enabled, true, "second breakpoint is still enabled");
-
-            breakpoints = devtools.deleteBreakpoint(todosLengthBreakpointId).detail.breakpoints;
-            assert.equal(breakpoints.length, 1, "first breakpoint is deleted");
-            assert.equal(breakpoints[0].expression, "person.nameChanges > 5", "remaining breakpoint has correct expression");
-            assert.equal(breakpoints[0].enabled, true, "remaining breakpoint is enabled");
-
-            breakpoints = devtools.deleteBreakpoint(nameChangesBreakpointId).detail.breakpoints;
-            assert.equal(breakpoints.length, 0, "remaining breakpoint is deleted");
-        });
-
-        it("binds and unbinds observation", () => {
-            const Todos = DefineList.extend("Todos", {});
-            const todos = new Todos();
-            let obs = new Observation(() => todos.length);
-            let breakpoints = devtools.addBreakpoint({
-                expression: "todos.length",
-                observation: obs
-            }).detail.breakpoints;
-
-            let breakpointId = breakpoints[0].id;
-
-            assert.ok(Reflect.isBound(obs), "addBreakpoint binds observation");
-
-            devtools.toggleBreakpoint(breakpointId);
-            assert.ok(!Reflect.isBound(obs), "toggleBreakpoint unbinds observation");
-
-            devtools.toggleBreakpoint(breakpointId);
-            assert.ok(Reflect.isBound(obs), "toggleBreakpoint re-binds observation");
-
-            devtools.deleteBreakpoint(breakpointId);
-            assert.ok(!Reflect.isBound(obs), "deleteBreakpoint unbinds observation");
-
-            breakpoints = devtools.addBreakpoint({
-                expression: "todos.length",
-                observation: obs,
-                enabled: false
-            }).detail.breakpoints;
-
-            assert.ok(!Reflect.isBound(obs), "addBreakpoint does not bind observation created with `enabled: false`");
-
-            breakpointId = breakpoints[0].id;
-
-            devtools.toggleBreakpoint(breakpointId);
-            assert.ok(Reflect.isBound(obs), "toggleBreakpoint binds observation created with `enabled: false`");
-
-            devtools.deleteBreakpoint(breakpointId);
-            assert.ok(!Reflect.isBound(obs), "deleteBreakpoint unbinds observation created with `enabled: false`");
-        });
-
-        it("handles errors", () => {
-            let resp = devtools.addBreakpoint({ error: "no component" });
-
-            assert.equal(resp.status, "error", "status === error");
-            assert.equal(resp.detail, "no component", "detail is the error message");
-        });
-    });
+	let devtools, windowCan;
+
+	before(() => {
+		// register devtools
+		debug();
+
+		// make sure devtools is not using global `can`
+		windowCan = window.can;
+		delete window.can;
+
+		// get access to devtools functions
+		devtools = window.__CANJS_DEVTOOLS__;
+	});
+
+	after(() => {
+		window.can = windowCan;
+	});
+
+	describe("getViewModelData", () => {
+		it("basics", () => {
+			class App extends StacheElement {
+				static get view() {
+					return "<p>{{ this.name }}</p>";
+				}
+				static get props() {
+					return {
+						first: "Kevin",
+						last: "McCallister",
+						get name() {
+							return this.first + " " + this.last;
+						}
+					};
+				}
+			}
+			customElements.define("a-pp-4", App);
+
+			const el = new App().render();
+
+			const {
+				viewModelData: viewModelDataFromEl,
+				tagName: tagNameFromEl,
+				typeNames: typeNamesFromEl
+			} = devtools.getViewModelData(el).detail;
+
+			assert.equal(tagNameFromEl, "<a-pp-4>", "tagName from el");
+			assert.deepEqual(
+				viewModelDataFromEl,
+				{ first: "Kevin", last: "McCallister", name: "Kevin McCallister" },
+				"viewModelData from el"
+			);
+			assert.deepEqual(typeNamesFromEl, {}, "typeNames from el");
+
+			const {
+				viewModelData: viewModelDataFromChild,
+				tagName: tagNameFromChild,
+				typeNames: typeNamesFromChild
+			} = devtools.getViewModelData(el.querySelector("p")).detail;
+
+			assert.equal(tagNameFromChild, "<a-pp-4>", "tagName from child of el");
+			assert.deepEqual(
+				viewModelDataFromChild,
+				{ first: "Kevin", last: "McCallister", name: "Kevin McCallister" },
+				"viewModelData from child of el"
+			);
+			assert.deepEqual(typeNamesFromChild, {}, "typeNames from child of el");
+		});
+
+		it("can handle elements", () => {
+			class AppWithElement extends StacheElement {
+				static get view() {
+					return "<p>this app has an element on its viewModelData</p>";
+				}
+
+				static get props() {
+					return {
+						element: {
+							get default() {
+								return document.createElement("p");
+							}
+						}
+					};
+				}
+			}
+
+			customElements.define("app-with-element", AppWithElement);
+
+			const el = new AppWithElement();
+			const { viewModelData, typeNames, messages } = devtools.getViewModelData(
+				el
+			).detail;
+
+			assert.deepEqual(
+				viewModelData,
+				{ element: {} },
+				"gets correct viewModelData data"
+			);
+
+			assert.deepEqual(
+				typeNames,
+				{ element: "HTMLParagraphElement{}" },
+				"gets correct name data"
+			);
+
+			assert.deepEqual(
+				messages,
+				{
+					element: {
+						type: "info",
+						message: "CanJS Devtools does not expand HTML Elements"
+					}
+				},
+				"gets correct message data"
+			);
+		});
+
+		it("can handle lists of elements", () => {
+			class AppWithListOfElements extends StacheElement {
+				static get view() {
+					return "<p>this app has a list of elements on its viewModel</p>";
+				}
+
+				static get props() {
+					return {
+						elements: {
+							get default() {
+								return new ObservableArray([
+									document.createElement("p"),
+									document.createElement("p")
+								]);
+							}
+						}
+					};
+				}
+			}
+
+			customElements.define("app-with-list-of-elements", AppWithListOfElements);
+
+			const el = new AppWithListOfElements().render();
+			const { viewModelData, typeNames, messages } = devtools.getViewModelData(
+				el
+			).detail;
+
+			assert.deepEqual(
+				viewModelData,
+				{ elements: {} },
+				"gets correct viewModelData data - unexpanded"
+			);
+
+			assert.deepEqual(
+				typeNames,
+				{ elements: "TypeConstructor[]" },
+				"gets correct name data - unexpanded"
+			);
+
+			assert.deepEqual(messages, {}, "gets correct message data - unexpanded");
+
+			const {
+				viewModelData: viewModelDataListExpanded,
+				typeNames: typeNamesListExpanded,
+				messages: messagesListExpanded
+			} = devtools.getViewModelData(el, { expandedKeys: ["elements"] }).detail;
+
+			assert.deepEqual(
+				viewModelDataListExpanded,
+				{ elements: { 0: {}, 1: {} } },
+				"gets correct viewModelData data - list expanded"
+			);
+
+			assert.deepEqual(
+				typeNamesListExpanded,
+				{
+					elements: "TypeConstructor[]",
+					"elements.0": "HTMLParagraphElement{}",
+					"elements.1": "HTMLParagraphElement{}"
+				},
+				"gets correct name data - list expanded"
+			);
+
+			assert.deepEqual(
+				messagesListExpanded,
+				{
+					"elements.0": {
+						type: "info",
+						message: "CanJS Devtools does not expand HTML Elements"
+					},
+					"elements.1": {
+						type: "info",
+						message: "CanJS Devtools does not expand HTML Elements"
+					}
+				},
+				"gets correct message data - list expanded"
+			);
+		});
+
+		it("can handle functions", () => {
+			class AppWithFunctions extends StacheElement {
+				static get view() {
+					return "<p>this app uses functions</p>";
+				}
+
+				static get props() {
+					return {
+						Thing: {
+							get default() {
+								return function Thing() {};
+							}
+						}
+					};
+				}
+			}
+
+			customElements.define("app-with-functions", AppWithFunctions);
+
+			const el = new AppWithFunctions();
+			const { viewModelData, typeNames, messages } = devtools.getViewModelData(
+				el
+			).detail;
+
+			assert.deepEqual(
+				viewModelData,
+				{ Thing: {} },
+				"shows an empty object for function so it can be expanded to show function source"
+			);
+
+			assert.deepEqual(
+				typeNames,
+				{ Thing: "function" },
+				"shows correct name for function"
+			);
+
+			assert.deepEqual(
+				messages,
+				{ Thing: { type: "info", message: "function Thing() {}" } },
+				"shows function source info message"
+			);
+		});
+
+		it("can handle circular references (#46)", () => {
+			const circular = {};
+			circular.circular = circular;
+
+			class CircularApp extends StacheElement {
+				static get view() {
+					return "<p>hello</p>";
+				}
+
+				static get props() {
+					return {
+						circular: {
+							type: DeepObservable,
+							get default() {
+								return circular;
+							}
+						}
+					};
+				}
+			}
+
+			customElements.define("circular-app-2", CircularApp);
+
+			const el = new CircularApp().initialize();
+			const { viewModelData, typeNames, messages } = devtools.getViewModelData(
+				el
+			).detail;
+
+			assert.deepEqual(
+				viewModelData,
+				{ circular: {} },
+				"gets empty object for circular property"
+			);
+
+			assert.deepEqual(
+				typeNames,
+				{ circular: "Object{}" },
+				"gets correct name for circular property"
+			);
+
+			assert.equal(typeof messages, "object");
+			assert.equal(typeof messages.circular, "object");
+			assert.equal(messages.circular.type, "error");
+			assert.ok(
+				messages.circular.message.match(/Error getting value of "circular":/)
+			);
+		});
+
+		it("can handle infinite recursion (#46)", () => {
+			class Thing extends ObservableObject {
+				static get props() {
+					return {
+						anotherThing: {
+							default() {
+								return new Thing();
+							}
+						}
+					};
+				}
+			}
+
+			class C extends StacheElement {
+				static get view() {
+					return "<p>hello</p>";
+				}
+
+				static get props() {
+					return {
+						thing: {
+							get default() {
+								return new Thing();
+							}
+						}
+					};
+				}
+			}
+
+			customElements.define("circular-app", C);
+
+			const el = new C().initialize();
+			const { viewModelData, typeNames } = devtools.getViewModelData(el).detail;
+
+			assert.deepEqual(
+				viewModelData,
+				{ thing: {} },
+				"gets empty object for recursive property"
+			);
+
+			assert.deepEqual(typeNames, { thing: "Thing{}" }, "gets correct name");
+		});
+
+		it("can handle nulls and undefineds", () => {
+			class C extends StacheElement {
+				static get view() {
+					return "<p>hello</p>";
+				}
+
+				static get props() {
+					return {
+						thisIsNull: { default: null, type: type.maybe(String) },
+						thisIsUndefined: { default: undefined, type: type.maybe(String) }
+					};
+				}
+			}
+
+			customElements.define("app-with-nulls", C);
+
+			const el = new C().initialize();
+
+			const { viewModelData, messages, undefineds } = devtools.getViewModelData(
+				el
+			).detail;
+
+			assert.deepEqual(
+				viewModelData,
+				{ thisIsNull: null, thisIsUndefined: undefined },
+				"gets null for property that is null and undefined for property that is undefined"
+			);
+
+			assert.deepEqual(
+				undefineds,
+				["thisIsUndefined"],
+				"gets undefineds array with paths whose value is `undefined`"
+			);
+
+			assert.deepEqual(messages, {}, "gets no messages");
+		});
+
+		it("can handle empty Maps / Lists / Objects / arrays", () => {
+			class C extends StacheElement {
+				static get view() {
+					return "<p>hello</p>";
+				}
+
+				static get props() {
+					return {
+						emptyMap: {
+							get default() {
+								return new ObservableObject();
+							}
+						},
+						emptyList: {
+							get default() {
+								return new ObservableArray();
+							}
+						},
+						emptyObject: {
+							type: type.Any,
+
+							get default() {
+								return {};
+							}
+						},
+						emptyArray: {
+							type: type.Any,
+
+							get default() {
+								return [];
+							}
+						}
+					};
+				}
+			}
+
+			customElements.define("app-with-empties", C);
+
+			const el = new C().render();
+
+			const { viewModelData, typeNames, messages } = devtools.getViewModelData(
+				el,
+				{ expandedKeys: ["emptyMap", "emptyList", "emptyObject", "emptyArray"] }
+			).detail;
+
+			assert.deepEqual(
+				viewModelData,
+				{
+					emptyMap: {},
+					emptyList: {},
+					emptyObject: {},
+					emptyArray: {}
+				},
+				"viewModelData properties are correct"
+			);
+
+			assert.deepEqual(
+				typeNames,
+				{
+					emptyMap: "TypeConstructor{}",
+					emptyList: "TypeConstructor[]",
+					emptyObject: "Object{}",
+					emptyArray: "Array[]"
+				},
+				"typeNames are correct"
+			);
+
+			assert.deepEqual(
+				messages,
+				{
+					emptyMap: { type: "info", message: "Map is empty" },
+					emptyList: { type: "info", message: "List is empty" },
+					emptyObject: { type: "info", message: "Object is empty" },
+					emptyArray: { type: "info", message: "Array is empty" }
+				},
+				"gets correct messages"
+			);
+		});
+	});
+
+	it("getNearestElementWithViewModel", () => {
+		class C extends StacheElement {
+			static get view() {
+				return "<p>{{ this.name }}</p>";
+			}
+
+			static get props() {
+				return {};
+			}
+		}
+
+		customElements.define("a-pp", C);
+
+		const el = new C().render();
+
+		assert.deepEqual(
+			devtools.getNearestElementWithViewModel(el),
+			el,
+			"gets element from element with a viewmodel"
+		);
+
+		assert.deepEqual(
+			devtools.getNearestElementWithViewModel(el.querySelector("p")),
+			el,
+			"gets element from child of element with a viewmodel"
+		);
+	});
+
+	describe("getSerializedViewModelData", () => {
+		it("viewModelData", () => {
+			class VM extends ObservableObject {
+				static get props() {
+					return {
+						name: String
+					};
+				}
+			}
+
+			assert.deepEqual(
+				devtools.getSerializedViewModelData(new VM()).viewModelData,
+				{ name: undefined },
+				"works for basic ViewModel"
+			);
+
+			class VM2 extends ObservableObject {
+				static get props() {
+					return {
+						first: { type: String, default: "Kevin" },
+						last: { type: String, default: "McCallister" },
+						get name() {
+							return this.first + " " + this.last;
+						}
+					};
+				}
+			}
+
+			assert.deepEqual(
+				devtools.getSerializedViewModelData(new VM2()).viewModelData,
+				{ first: "Kevin", last: "McCallister", name: "Kevin McCallister" },
+				"works for ViewModel with serialized properties"
+			);
+
+			class VM3 extends ObservableObject {
+				static get props() {
+					return {
+						hobbies: {
+							get default() {
+								return [{ name: "singing" }, { name: "dancing" }];
+							}
+						}
+					};
+				}
+			}
+
+			assert.deepEqual(
+				devtools.getSerializedViewModelData(new VM3()).viewModelData,
+				{ hobbies: {} },
+				"works for ObservableObject with nested array - unexpanded"
+			);
+
+			assert.deepEqual(
+				devtools.getSerializedViewModelData(new VM3(), {
+					expandedKeys: ["hobbies"]
+				}).viewModelData,
+				{ hobbies: { 0: {}, 1: {} } },
+				"works for ObservableObject with nested array - array expanded"
+			);
+
+			assert.deepEqual(
+				devtools.getSerializedViewModelData(new VM3(), {
+					expandedKeys: ["hobbies", "hobbies.0", "hobbies.1"]
+				}).viewModelData,
+				{ hobbies: { 0: { name: "singing" }, 1: { name: "dancing" } } },
+				"works for ObservableObject with nested array - all expanded"
+			);
+
+			class Hobby extends ObservableObject {
+				static get props() {
+					return {
+						name: String
+					};
+				}
+			}
+
+			class Hobbies extends ObservableArray {
+				static get items() {
+					return type.convert(Hobby);
+				}
+			}
+
+			class VM4 extends ObservableObject {
+				static get props() {
+					return {
+						hobbies: {
+							get default() {
+								return new Hobbies([{ name: "singing" }, { name: "dancing" }]);
+							}
+						}
+					};
+				}
+			}
+
+			assert.deepEqual(
+				devtools.getSerializedViewModelData(new VM4()).viewModelData,
+				{ hobbies: {} },
+				"works for nested ObservableObjects - unexpanded"
+			);
+
+			assert.deepEqual(
+				devtools.getSerializedViewModelData(new VM4(), {
+					expandedKeys: ["hobbies"]
+				}).viewModelData,
+				{ hobbies: { 0: {}, 1: {} } },
+				"works for nested ObservableObjects - array expanded"
+			);
+
+			assert.deepEqual(
+				devtools.getSerializedViewModelData(new VM4(), {
+					expandedKeys: ["hobbies", "hobbies.0", "hobbies.1"]
+				}).viewModelData,
+				{ hobbies: { 0: { name: "singing" }, 1: { name: "dancing" } } },
+				"works for nested ObservableObjects - everything expanded"
+			);
+
+			class PersonName extends ObservableObject {
+				static get props() {
+					return {
+						first: { type: String, default: "kevin" },
+						last: { type: String, default: "phillips" }
+					};
+				}
+			}
+
+			class VM5 extends ObservableObject {
+				static get props() {
+					return {
+						name: {
+							get default() {
+								return new PersonName();
+							}
+						},
+						age: { default: 32 }
+					};
+				}
+			}
+
+			assert.deepEqual(
+				devtools.getSerializedViewModelData(new VM5()).viewModelData,
+				{ age: 32, name: {} },
+				"only serializes top-level properties by default"
+			);
+		});
+
+		it("typeNames", () => {
+			class AThing extends ObservableObject {}
+
+			class VM extends ObservableObject {
+				static get props() {
+					return {
+						aThing: {
+							get default() {
+								return new AThing();
+							}
+						}
+					};
+				}
+			}
+
+			assert.deepEqual(
+				devtools.getSerializedViewModelData(new VM()).typeNames,
+				{ aThing: "AThing{}" },
+				"AThing{} - nothing expanded"
+			);
+
+			class ListOfThings extends ObservableArray {
+				static get items() {
+					return type.convert(AThing);
+				}
+			}
+
+			class VM2 extends ObservableObject {
+				static get props() {
+					return {
+						things: {
+							get default() {
+								return new ListOfThings([{}]);
+							}
+						}
+					};
+				}
+			}
+
+			assert.deepEqual(
+				devtools.getSerializedViewModelData(new VM2()).typeNames,
+				{ things: "ListOfThings[]" },
+				"ListOfThings[] - nothing expanded"
+			);
+
+			assert.deepEqual(
+				devtools.getSerializedViewModelData(new VM2(), {
+					expandedKeys: ["things"]
+				}).typeNames,
+				{ things: "ListOfThings[]", "things.0": "AThing{}" },
+				"ListOfThings[] - list expanded"
+			);
+
+			class Name extends ObservableObject {}
+			class NamedThing extends ObservableObject {
+				static get props() {
+					return {
+						name: type.convert(Name)
+					};
+				}
+			}
+			class ListOfNamedThings extends ObservableArray {
+				static get items() {
+					return type.convert(NamedThing);
+				}
+			}
+
+			class VM3 extends ObservableObject {
+				static get props() {
+					return {
+						things: {
+							get default() {
+								return new ListOfNamedThings([{ name: {} }]);
+							}
+						}
+					};
+				}
+			}
+
+			assert.deepEqual(
+				devtools.getSerializedViewModelData(new VM3()).typeNames,
+				{ things: "ListOfNamedThings[]" },
+				"ListOfNamedThings[] - nothing expanded"
+			);
+			assert.deepEqual(
+				devtools.getSerializedViewModelData(new VM3(), {
+					expandedKeys: ["things"]
+				}).typeNames,
+				{ things: "ListOfNamedThings[]", "things.0": "NamedThing{}" },
+				"ListOfNamedThings[] - list expanded"
+			);
+			assert.deepEqual(
+				devtools.getSerializedViewModelData(new VM3(), {
+					expandedKeys: ["things", "things.0"]
+				}).typeNames,
+				{
+					things: "ListOfNamedThings[]",
+					"things.0": "NamedThing{}",
+					"things.0.name": "Name{}"
+				},
+				"ListOfNamedThings[] - everything expanded"
+			);
+		});
+
+		it("undefineds", () => {
+			class ViewModel extends ObservableObject {
+				static get props() {
+					return {
+						thisIsUndefined: { default: undefined, type: type.convert(String) },
+						obj: {
+							get default() {
+								return new ObservableObject({
+									thisIsUndefined: undefined
+								});
+							}
+						}
+					};
+				}
+			}
+
+			assert.deepEqual(
+				devtools.getSerializedViewModelData(new ViewModel()).undefineds,
+				["thisIsUndefined"],
+				"nothing expanded"
+			);
+
+			assert.deepEqual(
+				devtools.getSerializedViewModelData(new ViewModel(), {
+					expandedKeys: ["obj"]
+				}).undefineds,
+				["thisIsUndefined", "obj.thisIsUndefined"],
+				"obj expanded"
+			);
+		});
+	});
+
+	it("updateViewModel", () => {
+		class C extends StacheElement {
+			static get view() {
+				return "<p>{{ this.name }}</p>";
+			}
+
+			static get props() {
+				return {
+					first: { type: type.maybeConvert(String), default: "Kevin" },
+					last: { type: type.maybeConvert(String), default: "McCallister" },
+					get name() {
+						return this.first + " " + this.last;
+					},
+					hobbies: {
+						type: type.Any,
+
+						get default() {
+							return ["running", "jumping"];
+						}
+					}
+				};
+			}
+		}
+
+		customElements.define("a-pp-2", C);
+
+		const el = new C().render();
+
+		assert.deepEqual(
+			devtools.getSerializedViewModelData(el, {
+				expandedKeys: ["hobbies"]
+			}).viewModelData,
+			{
+				first: "Kevin",
+				last: "McCallister",
+				name: "Kevin McCallister",
+				hobbies: { 0: "running", 1: "jumping" }
+			},
+			"default viewmodel data"
+		);
+
+		devtools.updateViewModel(el, [
+			{ type: "set", key: "first", value: "Marty" },
+			{ type: "set", key: "last", value: "McFly" }
+		]);
+
+		assert.deepEqual(
+			devtools.getSerializedViewModelData(el, {
+				expandedKeys: ["hobbies"]
+			}).viewModelData,
+			{
+				first: "Marty",
+				last: "McFly",
+				name: "Marty McFly",
+				hobbies: { 0: "running", 1: "jumping" }
+			},
+			"set works"
+		);
+
+		devtools.updateViewModel(el, [{ type: "delete", key: "last" }]);
+
+		assert.deepEqual(
+			devtools.getSerializedViewModelData(el, {
+				expandedKeys: ["hobbies"]
+			}).viewModelData,
+			{
+				first: "Marty",
+				last: undefined,
+				name: "Marty undefined",
+				hobbies: { 0: "running", 1: "jumping" }
+			},
+			"delete works"
+		);
+
+		devtools.updateViewModel(el, [
+			{
+				type: "splice",
+				key: "hobbies",
+				index: 0,
+				deleteCount: 1,
+				insert: ["skipping"]
+			}
+		]);
+
+		assert.deepEqual(
+			devtools.getSerializedViewModelData(el, {
+				expandedKeys: ["hobbies"]
+			}).viewModelData,
+			{
+				first: "Marty",
+				last: undefined,
+				name: "Marty undefined",
+				hobbies: { 0: "skipping", 1: "jumping" }
+			},
+			"splice works"
+		);
+	});
+
+	it("getViewModelKeys", () => {
+		class C extends StacheElement {
+			static get view() {
+				return "<p>{{ this.name }}</p>";
+			}
+
+			static get props() {
+				return {
+					first: { type: String, default: "Kevin" },
+					last: { type: String, default: "McCallister" },
+					get name() {
+						return this.first + " " + this.last;
+					}
+				};
+			}
+		}
+
+		customElements.define("a-pp-3", C);
+
+		const el = new C().initialize();
+
+		assert.deepEqual(
+			devtools.getViewModelKeys(el),
+			["first", "last", "name"],
+			"gets viewmodel keys"
+		);
+
+		const list = new ObservableArray([{ one: "two" }, { three: "four" }]);
+		assert.deepEqual(
+			devtools.getViewModelKeys(list),
+			["0", "1"],
+			"ignore _ keys for ObservableArray"
+		);
+	});
+
+	describe("component tree", () => {
+		let appOne, appTwo, appThree, treeData;
+		const fixture = document.getElementById("mocha-fixture");
+
+		// run once before all tests in this describe
+		// so that component IDs do not change between tests
+		before(() => {
+			// <a-pp>
+			//   <div>
+			//      <a-child>
+			//          <a-deep-child/>
+			//      </a-child>
+			//   </div>
+			//   <a-nother-child>
+			//      <p>
+			//          <a-nother-deep-child/>
+			//      </p>
+			//   </a-nother-child>
+			// </a-pp>
+			// <a-pp>
+			//   <div>
+			//      <a-child>
+			//          <a-deep-child/>
+			//      </a-child>
+			//   </div>
+			//   <a-nother-child>
+			//      <p>
+			//          <a-nother-deep-child/>
+			//      </p>
+			//   </a-nother-child>
+			// </a-pp>
+			class AChild extends StacheElement {
+				static get view() {
+					return "<a-deep-child/>";
+				}
+
+				static get props() {
+					return {};
+				}
+			}
+
+			customElements.define("a-child", AChild);
+
+			class ADeepChild extends StacheElement {
+				static get view() {
+					return "<p>a deep child</p>";
+				}
+
+				static get props() {
+					return {};
+				}
+			}
+
+			customElements.define("a-deep-child", ADeepChild);
+
+			class ANotherChild extends StacheElement {
+				static get view() {
+					return "<p><a-nother-deep-child/></p>";
+				}
+
+				static get props() {
+					return {};
+				}
+			}
+
+			customElements.define("a-nother-child", ANotherChild);
+
+			class ANotherDeepChild extends StacheElement {
+				static get view() {
+					return "<p>another deep child</p>";
+				}
+
+				static get props() {
+					return {};
+				}
+			}
+
+			customElements.define("a-nother-deep-child", ANotherDeepChild);
+
+			class App extends StacheElement {
+				static get view() {
+					return `
+						<div>
+							<a-child />
+						</div>
+						<a-nother-child/>
+					`;
+				}
+
+				static get props() {
+					return {};
+				}
+			}
+
+			customElements.define("a-pp-5", App);
+
+			appOne = new App().render();
+			appTwo = new App().render();
+
+			appThree = document.createElement("aa-pp");
+			appThree[Symbol.for("can.viewModel")] = appThree;
+
+			fixture.appendChild(appOne);
+			fixture.appendChild(appTwo);
+			fixture.appendChild(appThree);
+
+			window.$0 = fixture.querySelector("a-nother-deep-child");
+
+			const resp = devtools.getComponentTreeData();
+			treeData = resp.detail.tree;
+		});
+
+		after(() => {
+			fixture.removeChild(appOne);
+			fixture.removeChild(appTwo);
+			fixture.removeChild(appThree);
+		});
+
+		it("getComponentTreeData", () => {
+			assert.deepEqual(treeData, [
+				{
+					path: "0",
+					selected: false,
+					tagName: "a-pp-5",
+					id: 0,
+					children: [
+						{
+							path: "0.children.0",
+							selected: false,
+							tagName: "a-child",
+							id: 1,
+							children: [
+								{
+									path: "0.children.0.children.0",
+									selected: false,
+									tagName: "a-deep-child",
+									id: 2,
+									children: []
+								}
+							]
+						},
+						{
+							path: "0.children.1",
+							selected: false,
+							tagName: "a-nother-child",
+							id: 3,
+							children: [
+								{
+									path: "0.children.1.children.0",
+									selected: true,
+									tagName: "a-nother-deep-child",
+									id: 4,
+									children: []
+								}
+							]
+						}
+					]
+				},
+				{
+					path: "1",
+					selected: false,
+					tagName: "a-pp-5",
+					id: 5,
+					children: [
+						{
+							path: "1.children.0",
+							selected: false,
+							tagName: "a-child",
+							id: 6,
+							children: [
+								{
+									path: "1.children.0.children.0",
+									selected: false,
+									tagName: "a-deep-child",
+									id: 7,
+									children: []
+								}
+							]
+						},
+						{
+							path: "1.children.1",
+							selected: false,
+							tagName: "a-nother-child",
+							id: 8,
+							children: [
+								{
+									path: "1.children.1.children.0",
+									selected: false,
+									tagName: "a-nother-deep-child",
+									id: 9,
+									children: []
+								}
+							]
+						}
+					]
+				},
+				{
+					path: "2",
+					selected: false,
+					tagName: "aa-pp",
+					id: 10,
+					children: []
+				}
+			]);
+		});
+
+		it("selectComponentById", () => {
+			devtools.selectComponentById(0);
+			assert.ok(isElement(devtools.$0), "App");
+			assert.equal(devtools.$0.tagName.toLowerCase(), "a-pp-5", "a-pp-5");
+
+			devtools.selectComponentById(1);
+			assert.ok(isElement(devtools.$0), "Child");
+			assert.equal(devtools.$0.tagName.toLowerCase(), "a-child", "a-child");
+
+			devtools.selectComponentById(2);
+			assert.ok(isElement(devtools.$0), "DeepChild");
+			assert.equal(
+				devtools.$0.tagName.toLowerCase(),
+				"a-deep-child",
+				"a-deep-child"
+			);
+
+			devtools.selectComponentById(3);
+			assert.ok(isElement(devtools.$0), "AnotherChild");
+			assert.equal(
+				devtools.$0.tagName.toLowerCase(),
+				"a-nother-child",
+				"a-nother-child"
+			);
+
+			devtools.selectComponentById(4);
+			assert.ok(isElement(devtools.$0), "AnotherDeepChild");
+			assert.equal(
+				devtools.$0.tagName.toLowerCase(),
+				"a-nother-deep-child",
+				"a-nother-deep-child"
+			);
+
+			devtools.selectComponentById(5);
+			assert.ok(isElement(devtools.$0), "App");
+			assert.equal(
+				devtools.$0.tagName.toLowerCase(),
+				"a-pp-5",
+				"second a-pp-5"
+			);
+
+			devtools.selectComponentById(6);
+			assert.ok(isElement(devtools.$0), "Child");
+			assert.equal(
+				devtools.$0.tagName.toLowerCase(),
+				"a-child",
+				"second a-child"
+			);
+
+			devtools.selectComponentById(7);
+			assert.ok(isElement(devtools.$0), "DeepChild");
+			assert.equal(
+				devtools.$0.tagName.toLowerCase(),
+				"a-deep-child",
+				"second a-deep-child"
+			);
+
+			devtools.selectComponentById(8);
+			assert.ok(isElement(devtools.$0), "AnotherChild");
+			assert.equal(
+				devtools.$0.tagName.toLowerCase(),
+				"a-nother-child",
+				"second a-nother-child"
+			);
+
+			devtools.selectComponentById(9);
+			assert.ok(isElement(devtools.$0), "AnotherDeepChild");
+			assert.equal(
+				devtools.$0.tagName.toLowerCase(),
+				"a-nother-deep-child",
+				"second a-nother-deep-child"
+			);
+
+			devtools.selectComponentById(10);
+			assert.ok(isElement(devtools.$0), "aa-pp");
+			assert.equal(
+				devtools.$0.tagName.toLowerCase(),
+				"aa-pp",
+				"the element is the viewmodel child"
+			);
+		});
+	});
+
+	describe("add / get / toggle / delete breakpoints", () => {
+		it("basics", () => {
+			let breakpoints = devtools.addBreakpoint({
+				expression: "todos.length"
+			}).detail.breakpoints;
+
+			assert.equal(breakpoints.length, 1, "addBreakpoint adds a breakpoint");
+			assert.equal(
+				breakpoints[0].expression,
+				"todos.length",
+				"first breakpoint has correct expression"
+			);
+			assert.equal(breakpoints[0].enabled, true, "first breakpoint is enabled");
+
+			const todosLengthBreakpointId = breakpoints[0].id;
+
+			assert.deepEqual(
+				devtools.getBreakpoints().detail.breakpoints,
+				breakpoints,
+				"getBreakpoints works"
+			);
+
+			breakpoints = devtools.addBreakpoint({
+				expression: "person.nameChanges > 5"
+			}).detail.breakpoints;
+
+			assert.equal(
+				breakpoints.length,
+				2,
+				"addBreakpoint adds a second breakpoint"
+			);
+			assert.equal(
+				breakpoints[1].expression,
+				"person.nameChanges > 5",
+				"second breakpoint has correct expression"
+			);
+			assert.equal(
+				breakpoints[1].enabled,
+				true,
+				"second breakpoint is enabled"
+			);
+
+			const nameChangesBreakpointId = breakpoints[1].id;
+
+			assert.deepEqual(
+				devtools.getBreakpoints().detail.breakpoints,
+				breakpoints,
+				"getBreakpoints still works"
+			);
+
+			breakpoints = devtools.toggleBreakpoint(todosLengthBreakpointId).detail
+				.breakpoints;
+			assert.equal(breakpoints[0].enabled, false, "breakpoint is disabled");
+			assert.equal(
+				breakpoints[1].enabled,
+				true,
+				"second breakpoint is enabled"
+			);
+
+			breakpoints = devtools.toggleBreakpoint(nameChangesBreakpointId).detail
+				.breakpoints;
+			assert.equal(breakpoints[0].enabled, false, "breakpoint is disabled");
+			assert.equal(
+				breakpoints[1].enabled,
+				false,
+				"second breakpoint is disabled"
+			);
+
+			breakpoints = devtools.toggleBreakpoint(nameChangesBreakpointId).detail
+				.breakpoints;
+			assert.equal(
+				breakpoints[0].enabled,
+				false,
+				"breakpoint is still disabled"
+			);
+			assert.equal(
+				breakpoints[1].enabled,
+				true,
+				"second breakpoint is re-enabled"
+			);
+
+			breakpoints = devtools.toggleBreakpoint(todosLengthBreakpointId).detail
+				.breakpoints;
+			assert.equal(breakpoints[0].enabled, true, "breakpoint is re-enabled");
+			assert.equal(
+				breakpoints[1].enabled,
+				true,
+				"second breakpoint is still enabled"
+			);
+
+			breakpoints = devtools.deleteBreakpoint(todosLengthBreakpointId).detail
+				.breakpoints;
+			assert.equal(breakpoints.length, 1, "first breakpoint is deleted");
+			assert.equal(
+				breakpoints[0].expression,
+				"person.nameChanges > 5",
+				"remaining breakpoint has correct expression"
+			);
+			assert.equal(
+				breakpoints[0].enabled,
+				true,
+				"remaining breakpoint is enabled"
+			);
+
+			breakpoints = devtools.deleteBreakpoint(nameChangesBreakpointId).detail
+				.breakpoints;
+			assert.equal(breakpoints.length, 0, "remaining breakpoint is deleted");
+		});
+
+		it("binds and unbinds observation", () => {
+			class Todos extends ObservableArray {}
+			const todos = new Todos();
+			let obs = new Observation(() => todos.length);
+			let breakpoints = devtools.addBreakpoint({
+				expression: "todos.length",
+				observation: obs
+			}).detail.breakpoints;
+
+			let breakpointId = breakpoints[0].id;
+
+			assert.ok(Reflect.isBound(obs), "addBreakpoint binds observation");
+
+			devtools.toggleBreakpoint(breakpointId);
+			assert.ok(!Reflect.isBound(obs), "toggleBreakpoint unbinds observation");
+
+			devtools.toggleBreakpoint(breakpointId);
+			assert.ok(Reflect.isBound(obs), "toggleBreakpoint re-binds observation");
+
+			devtools.deleteBreakpoint(breakpointId);
+			assert.ok(!Reflect.isBound(obs), "deleteBreakpoint unbinds observation");
+
+			breakpoints = devtools.addBreakpoint({
+				expression: "todos.length",
+				observation: obs,
+				enabled: false
+			}).detail.breakpoints;
+
+			assert.ok(
+				!Reflect.isBound(obs),
+				"addBreakpoint does not bind observation created with `enabled: false`"
+			);
+
+			breakpointId = breakpoints[0].id;
+
+			devtools.toggleBreakpoint(breakpointId);
+			assert.ok(
+				Reflect.isBound(obs),
+				"toggleBreakpoint binds observation created with `enabled: false`"
+			);
+
+			devtools.deleteBreakpoint(breakpointId);
+			assert.ok(
+				!Reflect.isBound(obs),
+				"deleteBreakpoint unbinds observation created with `enabled: false`"
+			);
+		});
+
+		it("handles errors", () => {
+			let resp = devtools.addBreakpoint({ error: "no component" });
+
+			assert.equal(resp.status, "error", "status === error");
+			assert.equal(resp.detail, "no component", "detail is the error message");
+		});
+	});
 });

--- a/test/injected-script-test.js
+++ b/test/injected-script-test.js
@@ -1,4 +1,5 @@
 import { assert } from "chai/chai";
+import DefineList from "can-define/list/list";
 import "steal-mocha";
 
 import {
@@ -889,7 +890,7 @@ describe("canjs-devtools-injected-script", () => {
 			"gets viewmodel keys"
 		);
 
-		const list = new ObservableArray([{ one: "two" }, { three: "four" }]);
+		const list = new DefineList([{ one: "two" }, { three: "four" }]);
 		assert.deepEqual(
 			devtools.getViewModelKeys(list),
 			["0", "1"],

--- a/test/mjs-test.html
+++ b/test/mjs-test.html
@@ -1,4 +1,16 @@
-<!doctype html>
-<script src="../node_modules/steal/steal.js"
-    mocha="bdd"
-    main="test/mjs-test"></script>
+<!DOCTYPE html>
+<html lang="en">
+	<head>
+		<meta charset="UTF-8" />
+		<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+		<meta http-equiv="X-UA-Compatible" content="ie=edge" />
+		<title>tests</title>
+	</head>
+	<body>
+		<script
+			src="../node_modules/steal/steal.js"
+			mocha="bdd"
+			main="test/mjs-test"
+		></script>
+	</body>
+</html>

--- a/test/test.html
+++ b/test/test.html
@@ -1,4 +1,16 @@
-<!doctype html>
-<script src="../node_modules/steal/steal.js"
-    mocha="bdd"
-    main="test/test"></script>
+<!DOCTYPE html>
+<html lang="en">
+	<head>
+		<meta charset="UTF-8" />
+		<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+		<meta http-equiv="X-UA-Compatible" content="ie=edge" />
+		<title>tests</title>
+	</head>
+	<body>
+		<script
+			src="../node_modules/steal/steal.js"
+			mocha="bdd"
+			main="test/test"
+		></script>
+	</body>
+</html>

--- a/viewmodel-editor/index.html
+++ b/viewmodel-editor/index.html
@@ -1,10 +1,16 @@
-<!doctype html>
+<!DOCTYPE html>
 <html>
-    <head>
-        <link rel="stylesheet" type="text/css" href="../node_modules/can-devtools-components/dist/can-devtools-components.css">
-    </head>
-    <body>
-        <canjs-devtools-viewmodel-editor></canjs-devtools-viewmodel-editor>
-        <script type="module" src="viewmodel-editor.mjs"></script>
-    </body>
+	<head>
+		<link
+			rel="stylesheet"
+			type="text/css"
+			href="../node_modules/can-devtools-components/dist/can-devtools-components.css"
+		/>
+	</head>
+	<body>
+		<canjs-devtools-viewmodel-editor
+			tagName:raw="the-who"
+		></canjs-devtools-viewmodel-editor>
+		<script type="module" src="viewmodel-editor.mjs"></script>
+	</body>
 </html>

--- a/viewmodel-editor/viewmodel-editor.mjs
+++ b/viewmodel-editor/viewmodel-editor.mjs
@@ -1,95 +1,113 @@
-import { Component, DefineMap, DefineList, Reflect } from "../node_modules/can-devtools-components/dist/viewmodel-editor.mjs";
+import {
+	ObservableArray,
+	ObservableObject,
+	Reflect,
+	StacheElement,
+	type
+} from "../node_modules/can-devtools-components/dist/viewmodel-editor.mjs";
 
 import helpers from "../canjs-devtools-helpers.mjs";
 
-Component.extend({
-    tag: "canjs-devtools-viewmodel-editor",
+class CanjsDevtoolsViewmodelEditor extends StacheElement {
+	static get view() {
+		return `
+			{{# if(this.editorError) }}
+				<h2>{{{ this.editorError }}}</h2>
+			{{ else }}
+				<viewmodel-editor
+					tagName:from="this.tagName"
+					viewModelData:from="this.viewModelData"
+					typeNamesData:from="this.typeNamesData"
+					messages:from="this.messages"
+					undefineds:from="this.undefineds"
+					updateValues:from="this.updateValues"
+					expandedKeys:to="this.expandedKeys"
+				></viewmodel-editor>
+			{{/ if }}
+		`;
+	}
 
-    view: `
-        {{#if error}}
-            <h2>{{{error}}}</h2>
-        {{else}}
-            <viewmodel-editor
-                tagName:from="tagName"
-                viewModelData:from="viewModelData"
-                typeNamesData:from="typeNamesData"
-                messages:from="messages"
-                undefineds:from="undefineds"
-                updateValues:from="updateValues"
-                expandedKeys:to="expandedKeys"
-            ></viewmodel-editor>
-        {{/if}}
-    `,
+	static get props() {
+		return {
+			tagName: { type: String, default: "" },
+			editorError: String,
+			viewModelData: type.convert(ObservableObject),
+			typeNamesData: type.convert(ObservableObject),
+			messages: type.convert(ObservableObject),
+			undefineds: type.convert(ObservableArray),
+			expandedKeys: type.convert(ObservableArray)
+		};
+	}
 
-    ViewModel: {
-        tagName: "string",
-        error: "string",
-        viewModelData: DefineMap,
-        typeNamesData: DefineMap,
-        messages: DefineMap,
-        undefineds: DefineList,
-        expandedKeys: DefineList,
+	connected() {
+		var vm = this;
 
-        updateValues: function(data) {
-            helpers.runDevtoolsFunction({
-                fnString: "updateViewModel($0, " + JSON.stringify(data) + ")"
-            });
-        },
+		var stopRefreshing = helpers.runDevtoolsFunction({
+			fn: () => {
+				return (
+					"getViewModelData($0, { expandedKeys: [ '" +
+					(vm.expandedKeys ? vm.expandedKeys.serialize().join("', '") : "") +
+					"' ] } )"
+				);
+			},
+			refreshInterval: 100,
+			success: function(result) {
+				var status = result.status;
+				var detail = result.detail;
 
-        connectedCallback() {
-            var vm = this;
+				switch (status) {
+					case "ignore":
+						break;
+					case "error":
+						vm.editorError = detail;
+						break;
+					case "success":
+						// if selected element changed, remove viewModel completely
+						if (vm.tagName !== detail.tagName) {
+							vm.editorError = null;
+							vm.tagName = detail.tagName;
+							vm.viewModelData = detail.viewModelData || {};
+							vm.typeNamesData = detail.typeNames || {};
+							vm.messages = detail.messages || {};
+							vm.undefineds = detail.undefineds || [];
+						} else {
+							if (vm.viewModelData) {
+								if (detail.viewModelData) {
+									Reflect.updateDeep(
+										vm.viewModelData,
+										detail.viewModelData || {}
+									);
+									vm.typeNamesData = detail.typeNames;
+									vm.messages = detail.messages;
+									vm.undefineds = detail.undefineds;
+								} else {
+									Reflect.deleteKeyValue(vm, "viewModelData");
+									Reflect.deleteKeyValue(vm, "typeNamesData");
+									Reflect.deleteKeyValue(vm, "messages");
+									Reflect.deleteKeyValue(vm, "undefineds");
+								}
+							} else {
+								Reflect.setKeyValue(vm, "viewModelData", detail.viewModelData);
+							}
+						}
+						break;
+				}
+			}
+		});
 
-            var stopRefreshing = helpers.runDevtoolsFunction({
-                fn: () => {
-                    return "getViewModelData($0, { expandedKeys: [ '" +
-                                (vm.expandedKeys ? vm.expandedKeys.serialize().join("', '") : "")+
-                            "' ] } )";
-                },
-                refreshInterval: 100,
-                success: function(result) {
-                    var status = result.status;
-                    var detail = result.detail;
+		return function disconnect() {
+			stopRefreshing();
+		};
+	}
 
-                    switch(status) {
-                        case "ignore":
-                            break;
-                        case "error":
-                            vm.error = detail;
-                            break;
-                        case "success":
-                            // if selected element changed, remove viewModel completely
-                            if (vm.tagName !== detail.tagName) {
-                                vm.error = null;
-                                vm.tagName = detail.tagName;
-                                vm.viewModelData = detail.viewModelData || {};
-                                vm.typeNamesData = detail.typeNames || {};
-                                vm.messages = detail.messages || {};
-                                vm.undefineds = detail.undefineds || [];
-                            } else {
-                                if (vm.viewModelData) {
-                                    if (detail.viewModelData) {
-                                        Reflect.updateDeep(vm.viewModelData, detail.viewModelData || {});
-                                        vm.typeNamesData = detail.typeNames;
-                                        vm.messages = detail.messages;
-                                        vm.undefineds = detail.undefineds;
-                                    } else {
-                                        Reflect.deleteKeyValue(vm, "viewModelData");
-                                        Reflect.deleteKeyValue(vm, "typeNamesData");
-                                        Reflect.deleteKeyValue(vm, "messages");
-                                        Reflect.deleteKeyValue(vm, "undefineds");
-                                    }
-                                } else {
-                                    Reflect.setKeyValue(vm, "viewModelData", detail.viewModelData);
-                                }
-                            }
-                            break;
-                    }
-                }
-            });
+	updateValues(data) {
+		helpers.runDevtoolsFunction({
+			fnString: "updateViewModel($0, " + JSON.stringify(data) + ")"
+		});
+	}
+}
 
-            return function disconnect() {
-                stopRefreshing();
-            };
-        }
-    }
-});
+customElements.define(
+	"canjs-devtools-viewmodel-editor",
+	CanjsDevtoolsViewmodelEditor
+);


### PR DESCRIPTION
All components are upgraded at this point and the component tests are passing as well.

~I am still working on injected-script-test...~ 

~Ran the codemod but some manual updates are still required.~
~There is a test marked with `.only`, that is the last one I was debugging. I found [an issue in can-observable-array](https://github.com/canjs/can-observable-array/issues/71)~

~There is also a [branch in can-devtools-components](https://github.com/canjs/can-devtools-components/tree/devtools) with some minor updates needed to get this repo's test passing (like missing exports)~

- [x] Get all tests passing
- [x] Merge https://github.com/canjs/can-devtools-components/pull/94
- [x] Update can-observable-array to 1.0.4 and make sure tests pass now.

