### PR TITLE
Convert panel.viewModelData into a DeepObservable

### DIFF
--- a/bindings-graph/bindings-graph.mjs
+++ b/bindings-graph/bindings-graph.mjs
@@ -68,9 +68,9 @@ class CanjsDevtoolsBindingsGraph extends StacheElement {
 							vm.bindingsError = detail;
 							break;
 						case "success":
-							vm.bindingsError = null;
+							vm.bindingsError = '';
 							vm.selectedObj = detail.selectedObj;
-							vm.availableKeys.replace(detail.availableKeys);
+							vm.availableKeys.splice(0, vm.availableKeys.length, ...detail.availableKeys);
 							if (detail.graphData) {
 								vm.graphData = detail.graphData;
 							} else {

--- a/canjs-devtools-helpers.mjs
+++ b/canjs-devtools-helpers.mjs
@@ -154,7 +154,7 @@ const helpers = {
 		return expression.replace(
 			/(^|\s|=|>|<|!|\/|%|\+|-|\*|&|\(|\)|~|\?|,|\[|\])([A-Za-z_])/g,
 			(match, delimiter, prop) => {
-				return `${delimiter}\$\{vmName\}.${prop}`;
+				return `${delimiter}$\{vmName}.${prop}`;
 			}
 		);
 	},
@@ -218,7 +218,7 @@ const helpers = {
 
 if (typeof chrome === "object" && chrome.runtime && chrome.runtime.onMessage) {
 	// listen to messages from the background script
-	chrome.runtime.onMessage.addListener((msg, sender) => {
+	chrome.runtime.onMessage.addListener((msg) => {
 		switch (msg.type) {
 			case "__CANJS_DEVTOOLS_UPDATE_FRAMES__":
 				helpers.registeredFrames = msg.frames;

--- a/package.json
+++ b/package.json
@@ -27,10 +27,10 @@
   },
   "homepage": "https://canjs.com",
   "dependencies": {
-    "can-devtools-components": "^0.11.10-0"
+    "can-devtools-components": "^0.11.10"
   },
   "devDependencies": {
-    "can": "^6.2.3",
+    "can": "^6.2.7",
     "can-define": "^2.8.0",
     "chai": "^4.2.0",
     "eslint": "^6.5.1",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "web": "http://bitovi.com/"
   },
   "scripts": {
-    "lint": "eslint . ",
+    "lint": "eslint --ext=js,mjs . ",
     "testee": "testee test/test.html --browsers firefox",
     "testee-mjs": "testee test/mjs-test.html --browsers firefox",
     "test": "npm run lint && npm run testee && npm run testee-mjs"
@@ -27,7 +27,7 @@
   },
   "homepage": "https://canjs.com",
   "dependencies": {
-    "can-devtools-components": "^0.11.10"
+    "can-devtools-components": "^0.11.11"
   },
   "devDependencies": {
     "can": "^6.2.7",

--- a/panel/panel.mjs
+++ b/panel/panel.mjs
@@ -53,10 +53,7 @@ export default class CanjsDevtoolsPanel extends StacheElement {
 			componentTree: type.convert(ObservableArray),
 
 			selectedNode: type.convert(ObservableObject),
-			tagName: {
-				type: String,
-				get default() { return ""; }
-			},
+			tagName: "",
 
 			// ViewModel Editor data
 			viewModelData: {
@@ -224,7 +221,7 @@ export default class CanjsDevtoolsPanel extends StacheElement {
 							vm.viewModelEditorError = detail;
 							break;
 						case "success":
-							vm.tagName = detail.tagName;
+							vm.tagName = detail.tagName || "";
 							Reflect.updateDeep(vm.viewModelData, detail.viewModelData || {});
 							vm.typeNamesData = detail.typeNames || {};
 							vm.messages = detail.messages || {};

--- a/panel/panel.mjs
+++ b/panel/panel.mjs
@@ -30,6 +30,7 @@ export default class CanjsDevtoolsPanel extends StacheElement {
 					addBreakpoint:from="this.addBreakpoint"
 					toggleBreakpoint:from="this.toggleBreakpoint"
 					deleteBreakpoint:from="this.deleteBreakpoint"
+					tagName:from="this.tagName"
 				></components-panel>
 			{{/ if }}
 		`;
@@ -52,6 +53,10 @@ export default class CanjsDevtoolsPanel extends StacheElement {
 			componentTree: type.convert(ObservableArray),
 
 			selectedNode: type.convert(ObservableObject),
+			tagName: {
+				type: String,
+				get default() { return ""; }
+			},
 
 			// ViewModel Editor data
 			viewModelData: {
@@ -219,6 +224,7 @@ export default class CanjsDevtoolsPanel extends StacheElement {
 							vm.viewModelEditorError = detail;
 							break;
 						case "success":
+							vm.tagName = detail.tagName;
 							Reflect.updateDeep(vm.viewModelData, detail.viewModelData || {});
 							vm.typeNamesData = detail.typeNames || {};
 							vm.messages = detail.messages || {};

--- a/panel/panel.mjs
+++ b/panel/panel.mjs
@@ -1,4 +1,5 @@
 import {
+	DeepObservable,
 	ObservableArray,
 	ObservableObject,
 	Reflect,
@@ -54,12 +55,12 @@ export default class CanjsDevtoolsPanel extends StacheElement {
 
 			// ViewModel Editor data
 			viewModelData: {
-				type: type.convert(ObservableObject),
+				type: DeepObservable,
 				value({ listenTo, lastSet, resolve }) {
 					listenTo(lastSet, resolve);
 					// when a new node is selected, reset the data
 					listenTo("selectedNode", () => {
-						resolve(new ObservableObject());
+						resolve(Reflect.new(DeepObservable, {}));
 					});
 				}
 			},

--- a/viewmodel-editor/viewmodel-editor.mjs
+++ b/viewmodel-editor/viewmodel-editor.mjs
@@ -1,4 +1,5 @@
 import {
+	DeepObservable,
 	ObservableArray,
 	ObservableObject,
 	Reflect,
@@ -31,7 +32,7 @@ class CanjsDevtoolsViewmodelEditor extends StacheElement {
 		return {
 			tagName: { type: String, default: "" },
 			editorError: String,
-			viewModelData: type.convert(ObservableObject),
+			viewModelData: type.convert(DeepObservable),
 			typeNamesData: type.convert(ObservableObject),
 			messages: type.convert(ObservableObject),
 			undefineds: type.convert(ObservableArray),

--- a/viewmodel-editor/viewmodel-editor.mjs
+++ b/viewmodel-editor/viewmodel-editor.mjs
@@ -32,7 +32,7 @@ class CanjsDevtoolsViewmodelEditor extends StacheElement {
 		return {
 			tagName: { type: String, default: "" },
 			editorError: String,
-			viewModelData: type.convert(DeepObservable),
+			viewModelData: DeepObservable,
 			typeNamesData: type.convert(ObservableObject),
 			messages: type.convert(ObservableObject),
 			undefineds: type.convert(ObservableArray),


### PR DESCRIPTION
Note: the following must be done in other packages before this PR can be accepted and merged:

* [x] merge and publish https://github.com/canjs/can-devtools-components/pull/105
* [x] merge and publish https://github.com/canjs/can-observable-array/pull/73
* [x] publish a new CanJS with the new version of can-observable array
* [x] add the latest can and can-devtools-components as dependencies.

An update to one or both of the dependencies will fix the breaking test.

UPDATE:  another bug was identified blocking release (in bindings-graph)
* [x] merge and publish https://github.com/canjs/can-devtools-components/pull/106
* [x] add the latest can-devtools-components as dependency.