### PR TITLE
Add guards against the same breakpoint being added multiple times

### DIFF
--- a/canjs-devtools-helpers.mjs
+++ b/canjs-devtools-helpers.mjs
@@ -116,7 +116,11 @@ const helpers = {
 			// when a frame is added or removed
 			// remove the old refresh handlers
 			// and re-create them
-			this.onFrameChange(frameChangeHandler);
+			// If the handler *does not* refresh,
+			//   do not rerun it.
+			if(options.refreshInterval) {
+				this.onFrameChange(frameChangeHandler);
+			}
 		};
 
 		runDevtoolsFunctionForAllUrls();
@@ -170,7 +174,8 @@ const helpers = {
 		selectedComponentStatement = "window.__CANJS_DEVTOOLS__.$0",
 		displayExpression = this.getDisplayExpression(expression),
 		pathStatement = "window.__CANJS_DEVTOOLS__.pathOf$0",
-		debuggerStatement = "debugger" // overwritable for testing
+		debuggerStatement = "debugger", // overwritable for testing
+		id
 	}) {
 		const isBooleanExpression = this.isBooleanExpression(observationExpression);
 
@@ -210,7 +215,8 @@ const helpers = {
 						observation: observation,
 						observationExpression: \`${observationExpression}\`,
 						path: ${pathStatement},
-						enabled: ${enabled}
+						enabled: ${enabled},
+						${ typeof id !== "undefined" ? `id: ${id}` : "" }
 				};
 		}())`;
 	}

--- a/canjs-devtools-injected-script.js
+++ b/canjs-devtools-injected-script.js
@@ -285,6 +285,7 @@
 			observationExpression,
 			error,
 			enabled = true,
+			id = nextBreakpointId++,
 			path
 		}) {
 			if (error) {
@@ -293,14 +294,19 @@
 
 			// serializable data only
 			const breakpoint = {
-				id: nextBreakpointId++,
+				id,
 				expression,
 				observationExpression,
 				enabled,
 				path
 			};
 
-			breakpoints.push(breakpoint);
+			const matching = breakpoints.filter(bp => bp.id === id)[0];
+			if(matching) {
+				Object.assign(matching, breakpoint);
+			} else {
+				breakpoints.push(breakpoint);
+			}
 
 			// send updated list of breakpoints to background script
 			sendEventToBackgroundScript({

--- a/canjs-devtools-injected-script.js
+++ b/canjs-devtools-injected-script.js
@@ -285,7 +285,7 @@
 			observationExpression,
 			error,
 			enabled = true,
-			id = nextBreakpointId++,
+			id = nextBreakpointId,
 			path
 		}) {
 			if (error) {
@@ -301,12 +301,13 @@
 				path
 			};
 
-			const matching = breakpoints.filter(bp => bp.id === id)[0];
+			const matching = breakpoints.find(bp => bp.id === id);
 			if(matching) {
 				Object.assign(matching, breakpoint);
 			} else {
 				breakpoints.push(breakpoint);
 			}
+			nextBreakpointId = Math.max(nextBreakpointId, id + 1);
 
 			// send updated list of breakpoints to background script
 			sendEventToBackgroundScript({

--- a/panel/panel.mjs
+++ b/panel/panel.mjs
@@ -253,9 +253,9 @@ export default class CanjsDevtoolsPanel extends StacheElement {
 						// be created on component's viewmodel for each breakpoint.
 						const storedBreakpoints = helpers.storedBreakpoints || [];
 
-						storedBreakpoints.forEach((bp, index) => {
+						storedBreakpoints.forEach((bp) => {
 							if (!bp.restored) {
-								let { expression, path, observationExpression, enabled } = bp;
+								let { expression, path, observationExpression, enabled, id } = bp;
 
 								const node = path.split(".").reduce((parent, key) => {
 									return parent && parent[key];
@@ -272,7 +272,8 @@ export default class CanjsDevtoolsPanel extends StacheElement {
 											observationExpression,
 											displayExpression: expression,
 											pathStatement: `"${path}"`,
-											enabled
+											enabled,
+											id
 										})})`,
 										success(result) {
 											const status = result.status;
@@ -286,7 +287,7 @@ export default class CanjsDevtoolsPanel extends StacheElement {
 													vm.breakpoints = detail.breakpoints;
 
 													// mark breakpoint once it has been restored so it will not be restored again
-													helpers.storedBreakpoints[index].restored = true;
+													bp.restored = true;
 													break;
 											}
 										}


### PR DESCRIPTION
Two major focuses of this PR:

* If an injected devtools function doesn't have a refreshInterval, it should only be run once, so the frame change handler will ignore it for frame startup/teardown.

* Allow the addBreakpoint() flow between devtools and injected functions to take the ID of a previously-known breakpoint, and don't re-add breakpoints that are already in the list by ID (but update their properties).

Fixes #90.