### PR TITLE
Fix permissions in the manifest

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -16,11 +16,11 @@
     {
       "all_frames": true,
       "js": ["canjs-devtools-content-script.js"],
-      "matches": ["*://*/*"]
+      "matches": ["<all_urls>"]
     }
   ],
   "web_accessible_resources": ["canjs-devtools-injected-script.js"],
-  "permissions": [],
+  "permissions": ["<all_urls>"],
   "content_security_policy": "script-src 'self' 'unsafe-eval'; object-src 'self'",
   "browser_action": {
     "default_title": "CanJS Devtools",


### PR DESCRIPTION
Update permissions in the manifest file as recommended by [google](https://developer.chrome.com/extensions/runtime_host_permissions) , [`"<all_urls>"`](https://developer.chrome.com/extensions/match_patterns) is used in `content_scripts` key and `"permissions` key.

Closes #94 