### PR TITLE
Update manifest.json permissions

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -14,13 +14,17 @@
   },
   "content_scripts": [
     {
-      "all_frames": true,
+      "matches": ["<all_urls>"],
       "js": ["canjs-devtools-content-script.js"],
-      "matches": ["<all_urls>"]
+      "run_at": "document_idle"
     }
   ],
   "web_accessible_resources": ["canjs-devtools-injected-script.js"],
-  "permissions": ["<all_urls>"],
+  "permissions": [
+    "http://*/*",
+    "https://*/*",
+    "file:///*"
+  ],
   "content_security_policy": "script-src 'self' 'unsafe-eval'; object-src 'self'",
   "browser_action": {
     "default_title": "CanJS Devtools",

--- a/manifest.json
+++ b/manifest.json
@@ -14,6 +14,7 @@
   },
   "content_scripts": [
     {
+      "all_frames": true,
       "matches": ["<all_urls>"],
       "js": ["canjs-devtools-content-script.js"],
       "run_at": "document_idle"


### PR DESCRIPTION
Closes #94 

1- Update `permissions` to detailed urls patterns:
```json
"permissions": [
    "http://*/*",
    "https://*/*",
    "file:///*"
  ]
```

2- Update `content_scripts`:
```json
"content_scripts": [
    {
      "matches": ["<all_urls>"],
      "js": ["canjs-devtools-content-script.js"],
      "run_at": "document_idle"
    }
  ]
```
Adding "run_at" with value "document_idle" as recommended in the [docs](https://developer.chrome.com/extensions/content_scripts) 
<img width="614" alt="Screen Shot 2020-01-13 at 4 51 18 PM" src="https://user-images.githubusercontent.com/109013/72270673-d4cb3b00-3625-11ea-9630-ee8568821a2c.png">
