### PR TITLE
Restore breakpoints with a dedicated message

### DIFF
--- a/canjs-devtools-injected-script.js
+++ b/canjs-devtools-injected-script.js
@@ -330,7 +330,9 @@
 			return this.getBreakpoints();
 		},
 		addBreakpoints(breakpoints) {
-			this.addBreakpoint(breakpoints);
+			breakpoints.forEach(breakpoint => {
+				this.addBreakpoint(breakpoint);
+			});
 			return this.getBreakpoints();
 		},
 

--- a/canjs-devtools-injected-script.js
+++ b/canjs-devtools-injected-script.js
@@ -329,6 +329,10 @@
 
 			return this.getBreakpoints();
 		},
+		addBreakpoints(breakpoints) {
+			this.addBreakpoint(breakpoints);
+			return this.getBreakpoints();
+		},
 
 		toggleBreakpoint(id) {
 			const index = getIndexOfItemInArrayWithId(breakpoints, id);

--- a/panel/panel.mjs
+++ b/panel/panel.mjs
@@ -253,10 +253,9 @@ export default class CanjsDevtoolsPanel extends StacheElement {
 						// be created on component's viewmodel for each breakpoint.
 						const storedBreakpoints = helpers.storedBreakpoints || [];
 
-						const bps = storedBreakpoints.map((bp) => {
+						const breakpoints = storedBreakpoints.map((bp) => {
 							if (!bp.restored) {
 								let { expression, path, observationExpression, enabled, id } = bp;
-								debugger;
 								const node = path.split(".").reduce((parent, key) => {
 									return parent && parent[key];
 								}, detail.tree);
@@ -277,13 +276,13 @@ export default class CanjsDevtoolsPanel extends StacheElement {
 								}
 
 							}
-							return bp;
+							//return bp;
 						});
-						if (bps.length) {
+						if (breakpoints.length) {
 							helpers.runDevtoolsFunction({
 								// indentation below is weird on purpose
 								// this is so it looks normal when a debugger is hit
-								fnString: `addBreakpoints([ ${bps.join(",")} ])`, //JSON.stringify or [ ${bps.join(",")} ]
+								fnString: `addBreakpoints([ ${JSON.stringify(breakpoints)} ])`, //JSON.stringify or [ ${bps.join(",")} ]
 								success(result) {
 									const status = result.status;
 									const detail = result.detail;

--- a/panel/panel.mjs
+++ b/panel/panel.mjs
@@ -256,12 +256,13 @@ export default class CanjsDevtoolsPanel extends StacheElement {
 						const bps = storedBreakpoints.map((bp) => {
 							if (!bp.restored) {
 								let { expression, path, observationExpression, enabled, id } = bp;
-
+								debugger;
 								const node = path.split(".").reduce((parent, key) => {
 									return parent && parent[key];
 								}, detail.tree);
 								
-								if (node && node.id) {
+								// if node does not exist in tree, do not set up breakpoint
+								if (node && typeof node.id !== undefined) {
 									// mark breakpoint once it has been restored so it will not be restored again
 									bp.restored = true;
 									return helpers.getBreakpointEvalString({
@@ -274,18 +275,19 @@ export default class CanjsDevtoolsPanel extends StacheElement {
 										id
 									});
 								}
-							}
-						});
 
-						// if node does not exist in tree, do not set up breakpoint
-						helpers.runDevtoolsFunction({
-							// indentation below is weird on purpose
-							// this is so it looks normal when a debugger is hit
-							fnString: `addBreakpoint(${bps})`,
+							}
+							return bp;
+						});
+						if (bps.length) {
+							helpers.runDevtoolsFunction({
+								// indentation below is weird on purpose
+								// this is so it looks normal when a debugger is hit
+								fnString: `addBreakpoints([ ${bps.join(",")} ])`, //JSON.stringify or [ ${bps.join(",")} ]
 								success(result) {
 									const status = result.status;
 									const detail = result.detail;
-
+	
 									switch (status) {
 										case "error":
 											vm.breakpointsError = detail;
@@ -293,9 +295,10 @@ export default class CanjsDevtoolsPanel extends StacheElement {
 										case "success":
 											vm.breakpoints = detail.breakpoints;
 											break;
+										}
 									}
-								}
-						});
+							});
+						}
 						break;
 					}
 				}

--- a/panel/panel.mjs
+++ b/panel/panel.mjs
@@ -283,7 +283,7 @@ export default class CanjsDevtoolsPanel extends StacheElement {
 							helpers.runDevtoolsFunction({
 								// indentation below is weird on purpose
 								// this is so it looks normal when a debugger is hit
-								fnString: `addBreakpoints([${breakpoints.join(",")}])`, //JSON.stringify or [ ${bps.join(",")} ]
+								fnString: `addBreakpoints([${breakpoints.join(",")}])`,
 								success(result) {
 									const status = result.status;
 									const detail = result.detail;

--- a/test/injected-script-test.js
+++ b/test/injected-script-test.js
@@ -1356,14 +1356,38 @@ describe("canjs-devtools-injected-script", () => {
 		it ('adds breakpoints', () => {
 			const breakpoints = devtools.addBreakpoints([{
 				expression: "todos.length"
+			},
+			{
+				expression: "breakpoint2"
+			},
+			{
+				expression: "anotherBreakpoint",
+				enabled: false
 			}]).detail.breakpoints;
-			assert.equal(breakpoints.length, 1, "addBreakpoints adds breakpoints");
+
+			assert.equal(breakpoints.length, 3, "addBreakpoints adds breakpoints");
+
 			assert.equal(
 				breakpoints[0].expression,
 				"todos.length",
 				"first breakpoint has correct expression"
 			);
+
+			assert.equal(
+				breakpoints[1].expression,
+				"breakpoint2",
+				"second breakpoint has correct expression"
+			);
+
+			assert.equal(
+				breakpoints[2].expression,
+				"anotherBreakpoint",
+				"third breakpoint has correct expression"
+			);
+
 			assert.equal(breakpoints[0].enabled, true, "first breakpoint is enabled");
+			assert.equal(breakpoints[1].enabled, true, "second breakpoint is enabled");
+			assert.equal(breakpoints[2].enabled, false, "third breakpoint is enabled");
 		});
 	});
 });

--- a/test/injected-script-test.js
+++ b/test/injected-script-test.js
@@ -1351,4 +1351,19 @@ describe("canjs-devtools-injected-script", () => {
 			assert.equal(resp.detail, "no component", "detail is the error message");
 		});
 	});
+
+	describe('addBreakpoints', () => {
+		it ('adds breakpoints', () => {
+			const breakpoints = devtools.addBreakpoints([{
+				expression: "todos.length"
+			}]).detail.breakpoints;
+			assert.equal(breakpoints.length, 1, "addBreakpoints adds breakpoints");
+			assert.equal(
+				breakpoints[0].expression,
+				"todos.length",
+				"first breakpoint has correct expression"
+			);
+			assert.equal(breakpoints[0].enabled, true, "first breakpoint is enabled");
+		});
+	});
 });


### PR DESCRIPTION
Closes #93 

Adds the ability to add breakpoints at once instead of loop through when refreshing the page in order to separate the devtools thread from the user thread.

Thank you @phillipskevin , I added the test.