### PR TITLE
Filter map metadata started with '_'

### DIFF
--- a/canjs-devtools-injected-script.js
+++ b/canjs-devtools-injected-script.js
@@ -519,11 +519,17 @@
 
 		getViewModelKeys(viewModel) {
 			if (canReflect.isListLike(viewModel)) {
-				return canReflect.getOwnEnumerableKeys(viewModel);
+				return canReflect.getOwnEnumerableKeys(viewModel).filter(key => {
+					if (typeof key === 'string') {
+						return key.startsWith('_') === false;
+					}
+				});
 			}
-
+			
 			if (canReflect.isMapLike(viewModel)) {
-				return canReflect.getOwnKeys(viewModel);
+				return canReflect.getOwnKeys(viewModel).filter(key => {
+					return key.startsWith('_') === false;
+				});
 			}
 		},
 

--- a/test/injected-script-test.js
+++ b/test/injected-script-test.js
@@ -10,7 +10,9 @@ import {
 	Observation,
 	Reflect,
 	StacheElement,
-	type
+	type,
+	CanMap,
+	CanList
 } from "can";
 import "../canjs-devtools-injected-script";
 
@@ -455,6 +457,42 @@ describe("canjs-devtools-injected-script", () => {
 				},
 				"gets correct messages"
 			);
+		});
+
+		it("getViewModelKeys filters keys started with '_'", () => {
+			class Custom extends StacheElement {
+				static get view() {
+					return "<p>{{ this.name }}</p>";
+				}
+		
+				static get props() {
+					return {
+						first: { type: String, default: "Kevin" },
+						last: { type: String, default: "McCallister" },
+						get name() {
+							return this.first + " " + this.last;
+						},
+						aCanMap: {
+							get default() {
+								return new CanMap({
+									foo: 'bar',
+									age: 38,
+									isTrue: false
+								})},
+							},
+							aList: {
+								get default() {
+									return new CanList(['foo', 'bar']);
+								}	
+							}
+					};
+				}
+			}
+			customElements.define("a-pp-6", Custom);
+			
+			const vm = new Custom().initialize();
+			assert.deepEqual(['foo', 'age', 'isTrue'], devtools.getViewModelKeys(vm.aCanMap));
+			assert.deepEqual([], devtools.getViewModelKeys(vm.aList));
 		});
 	});
 


### PR DESCRIPTION
injected script`getViewModelKeys` method now filters the viewModel keys that start with `_` like `can-map` metadata (eg: `_data`) in order the prevent `undefineds` error in `can-devtools-components` `panel` component.

Closes https://github.com/canjs/can-devtools-components/issues/108